### PR TITLE
feat: trigger control group SCPI mappings

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -5,6 +5,7 @@ from pyvisa.resources import MessageBasedResource
 
 from tekafp.input import Input
 from tekafp.uart import UARTBridge
+from tekafp.util import clamp, parse_resp
 
 
 # UART config
@@ -49,10 +50,6 @@ def connect_uart() -> UARTBridge:
         raise RuntimeError(f"Failed to open UART on {PORT}")
     print(f"Connected UART: {PORT} @ {BAUD}")
     return bridge
-
-
-def clamp(x: float, lo: float, hi: float) -> float:
-    return max(lo, min(hi, x))
 
 
 class Controller:
@@ -103,6 +100,33 @@ class Controller:
         self.scope.write(f"HORIZONTAL:POSITION {new}")
         print(f"[SCOPE] horizontal position (%): {cur:.2f} -> {new:.2f}")
 
+    def encoder_trigger_level(self, detents: int) -> None:
+        # TODO: ask antonio how he landed on HORIZ_STEP_PCT (need value for trigger lvl)
+        ch = self.active_ch
+        ab = "A"
+        query = f"TRIGGER:{ab}:LEVEL:CH{ch}"
+        cur: float = parse_resp(self.scope.query(query + "?"), float)
+
+        new = cur + detents * HORIZ_STEP_PCT
+        new = clamp(new, 0.0, 100.0)
+
+        self.scope.write(query + f" {new}")
+        print(f"[SCOPE] trigger level (%): {cur:.2f} -> {new:.2f}")
+
+    def next_trigger_slope(self) -> None:
+        cur: str = parse_resp(self.scope.query("TRIGGER:A:EDGE:SLOPE?"), str).upper()
+        new: str = ""
+        match cur:
+            case "RISE":
+                new = "FALL"
+            case "FALL":
+                new = "EITHER"
+            case "EITHER":
+                new = "RISE"
+            case _:
+                raise AssertionError("Invalid trigger slope. Something is wrong!")
+        self.scope.write(f"TRIGGER:A:EDGE:SLOPE {new}")
+
     # UART event handler
     def handle_input(self, inp: Input) -> None:
         """
@@ -134,6 +158,34 @@ class Controller:
             detents = int(val)
             if detents:
                 self.adjust_horizontal_position(detents)
+            return
+
+        # trigger level encoder
+        if msg_id == "TL1":
+            detents = int(val)
+            if detents:
+                self.encoder_trigger_level(detents)
+            return
+        # trigger level push
+        if msg_id == "TL0":
+            self.scope.write("TRIGGER:A: SETLevel")
+            return
+
+        # trigger force
+        if msg_id == "TF0":
+            self.scope.write("TRIGGER FORCE")
+            return
+
+        # trigger slope type
+        if msg_id == "TS0":
+            self.next_trigger_slope()
+            return
+
+        # trigger mode
+        if msg_id == "TM0":
+            cur: str = parse_resp(self.scope.query("TRIGGER:A:MODE?"), str).upper()
+            new: str = "AUTO" if cur == "NORMAL" else "NORMAL"
+            self.scope.write(f"TRIGGER:A:MODE {new}")
             return
 
 def main() -> None:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -108,7 +108,7 @@ class Controller:
 
         trigger_scale: float = 0.4
         new = cur + detents * trigger_scale
-        new = clamp(new, 0.0, 100.0)
+        new = clamp(new, -100.0, 100.0)
 
         self.scope.write(query + f" {new}")
         print(f"[SCOPE] trigger level (%): {cur:.2f} -> {new:.2f}")

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -101,13 +101,13 @@ class Controller:
         print(f"[SCOPE] horizontal position (%): {cur:.2f} -> {new:.2f}")
 
     def encoder_trigger_level(self, detents: int) -> None:
-        # TODO: ask antonio how he landed on HORIZ_STEP_PCT (need value for trigger lvl)
         ch = self.active_ch
         ab = "A"
         query = f"TRIGGER:{ab}:LEVEL:CH{ch}"
         cur: float = parse_resp(self.scope.query(query + "?"), float)
 
-        new = cur + detents * HORIZ_STEP_PCT
+        trigger_scale: float = 0.4
+        new = cur + detents * trigger_scale
         new = clamp(new, 0.0, 100.0)
 
         self.scope.write(query + f" {new}")

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -101,9 +101,11 @@ class Controller:
         print(f"[SCOPE] horizontal position (%): {cur:.2f} -> {new:.2f}")
 
     def encoder_trigger_level(self, detents: int) -> None:
-        ch = self.active_ch
+        # FIXME: the MSO has both A (primary) and B (delay) triggers for sequencing.
+        # for now, default to A
         ab = "A"
-        query = f"TRIGGER:{ab}:LEVEL:CH{ch}"
+        source: str = parse_resp(self.scope.query(f"TRIGGER:{ab}:EDGE:SOURCE?"), str)
+        query = f"TRIGGER:{ab}:LEVEL:CH{source}"
         cur: float = parse_resp(self.scope.query(query + "?"), float)
 
         trigger_scale: float = 0.4

--- a/software/tekafp/util/__init__.py
+++ b/software/tekafp/util/__init__.py
@@ -1,0 +1,5 @@
+def parse_resp(resp: str, rtype: type[float | int | str]) -> float | int | str:
+    return rtype(resp.strip().split()[-1])
+
+def clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))


### PR DESCRIPTION
Trigger control category SCPI mappings:

- [x] Trigger Level encoder
- [x] Trigger Level encoder push button
- [x] Trigger Force
- [x] Trigger slope type
- [x] Trigger mode

Currently takes into account the active channel, but only affects trigger A. Sequence triggering pretty much requires being at the scope to use the configuration menus -- not sure if we want to support A-B trigger modes, or not.

Closes #13 