### PR TITLE
Introduce channel selection state machine to match MSO behavior

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -97,7 +97,7 @@ class Controller:
         )
 
     def adjust_vertical_position(self, detents: int) -> None:
-        ch = self.active_channel
+        ch = self._source_channel
         cur = float(self.scope.query(f"CH{ch}:POSITION?").strip().split()[-1])
 
         new = cur + detents * VERT_STEP_DIVS
@@ -150,7 +150,7 @@ class Controller:
     def toggle_run_stop(self) -> None:
         resp = self.scope.query("ACQUIRE:STATE?").strip().upper()
 
-        # Tek scopes may return RUN/STOP, ON/OFF, or 1/0 
+        # Tek scopes may return RUN/STOP, ON/OFF, or 1/0
         if resp in ("RUN", "ON", "1"):
             self.scope.write("ACQUIRE:STATE STOP")
             print("[SCOPE] Run/Stop -> STOP")
@@ -219,7 +219,7 @@ class Controller:
             new: str = "AUTO" if cur == "NORMAL" else "NORMAL"
             self.scope.write(f"TRIGGER:A:MODE {new}")
             return
-        
+
         # Run/Stop button
         if msg_id == "AR0":
             self.toggle_run_stop()

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,5 +1,4 @@
 import time
-from typing import List
 
 import pyvisa
 from pyvisa.resources import MessageBasedResource

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -60,38 +60,44 @@ class Controller:
     def __init__(self, scope: MessageBasedResource) -> None:
         self.scope: MessageBasedResource = scope
 
-        # first item is LRU, last is MRU, therefore MRU is the active channel.
-        # if a channel is in this list, it is enabled
-        self._channel_lru: List[int] = []
+        self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
+        self._source_channel: int = 0
 
-    def is_channel_enabled(self, channel: int) -> bool:
-        return channel in self._channel_lru
-
-    @property
-    def active_channel(self) -> int:
-        """Get the currently active channel."""
-        return 0 if len(self._channel_lru) == 0 else self._channel_lru[-1]
-
-    # Scope helpers
     def set_channel_display(self, channel: int) -> None:
-        state: bool = self.is_channel_enabled(channel)
-        if state:
-            # enabled
-            if self.active_channel == channel:
-                # enabled and active => disable it
-                self._channel_lru.pop()
-            else:
-                # enabled and NOT active => select it
-                self._channel_lru.remove(channel)
-                self._channel_lru.append(channel)
+        if channel not in range(1, 9):
+            return
+        last_state: bool = self._channels[channel]
+
+        if self._source_channel == channel:
+            # enabled and source => disable, select highest enabled as active
+            self._channels[channel] = False
+            highest: int = 0
+            for k, v in self._channels.items():
+                if v:
+                    highest = k
+                    if k > channel:
+                        break
+            self._source_channel = highest
+        elif last_state:
+            # enabled => set as source
+            self._source_channel = channel
         else:
-            # disabled
-            self._channel_lru.append(channel)
-        state = self.is_channel_enabled(channel)
-        self.scope.write(f"DISPLAY:GLOBAL:CH{channel}:STATE {1 if state else 0}")
+            # disabled => enable, set as source
+            self._channels[channel] = True
+            self._source_channel = channel
+
+        if self._source_channel == 0:
+            self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
+        else:
+            self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+        if last_state != self._channels[channel]:
+            self.scope.write(
+                f"DISPLAY:GLOBAL:CH{channel}:STATE {int(self._channels[channel])}"
+            )
 
         print(
-            f"[SCOPE] CH{channel} display -> {'ON' if state else 'OFF'} (active_ch={self.active_channel})"  # noqa: E501
+            f"[SCOPE] CH{channel} display -> {self._channels[channel]} (source={self._source_channel})"  # noqa: E501
         )
 
     def adjust_vertical_position(self, detents: int) -> None:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,4 +1,5 @@
 import time
+from typing import List
 
 import pyvisa
 from pyvisa.resources import MessageBasedResource
@@ -59,31 +60,42 @@ class Controller:
     def __init__(self, scope: MessageBasedResource) -> None:
         self.scope: MessageBasedResource = scope
 
-        # Track CH1..CH6 on/off state to support "current active channel"
-        self.ch_enabled = {ch: False for ch in range(1, 7)}
-        self.active_ch = 1  # Default if nothing has been enabled yet
+        # first item is LRU, last is MRU, therefore MRU is the active channel.
+        # if a channel is in this list, it is enabled
+        self._channel_lru: List[int] = []
+
+    def is_channel_enabled(self, channel: int) -> bool:
+        return channel in self._channel_lru
+
+    @property
+    def active_channel(self) -> int:
+        """Get the currently active channel."""
+        return 0 if len(self._channel_lru) == 0 else self._channel_lru[-1]
 
     # Scope helpers
-    def set_channel_display(self, ch: int, on: bool) -> None:
-        # DISplay:GLObal:CH<x>:STATE {ON|OFF|0|1}
-        self.scope.write(f"DISPLAY:GLOBAL:CH{ch}:STATE {1 if on else 0}")
-
-        self.ch_enabled[ch] = on
-        if on:
-            self.active_ch = ch
+    def set_channel_display(self, channel: int) -> None:
+        state: bool = self.is_channel_enabled(channel)
+        if state:
+            # enabled
+            if self.active_channel == channel:
+                # enabled and active => disable it
+                self._channel_lru.pop()
+            else:
+                # enabled and NOT active => select it
+                self._channel_lru.remove(channel)
+                self._channel_lru.append(channel)
         else:
-            # If we turned off the active channel, pick another enabled one (lowest #)
-            # else default to 1
-            if self.active_ch == ch:
-                enabled = [c for c, state in self.ch_enabled.items() if state]
-                self.active_ch = enabled[0] if enabled else 1
+            # disabled
+            self._channel_lru.append(channel)
+        state = self.is_channel_enabled(channel)
+        self.scope.write(f"DISPLAY:GLOBAL:CH{channel}:STATE {1 if state else 0}")
 
         print(
-            f"[SCOPE] CH{ch} display -> {'ON' if on else 'OFF'} (active_ch={self.active_ch})"  # noqa: E501
+            f"[SCOPE] CH{channel} display -> {'ON' if state else 'OFF'} (active_ch={self.active_channel})"  # noqa: E501
         )
 
     def adjust_vertical_position(self, detents: int) -> None:
-        ch = self.active_ch
+        ch = self.active_channel
         cur = float(self.scope.query(f"CH{ch}:POSITION?").strip().split()[-1])
 
         new = cur + detents * VERT_STEP_DIVS
@@ -107,7 +119,7 @@ class Controller:
     def handle_input(self, inp: Input) -> None:
         """
         inp.id is expected to be strings like:
-          V10..V60, KA1/KA0, KB1/KB0, etc.
+          V10..V80, KA1/KA0, KB1/KB0, etc.
         inp.value for encoders is expected +/-1 per detent.
         inp.value for toggles is expected 0/1 (latched state).
         """
@@ -115,11 +127,10 @@ class Controller:
         msg_id = str(inp.id)
         val = inp.value
 
-        # Channel toggles: V10..V60 => CH1..CH6 display on/off
-        if msg_id in ("V10", "V20", "V30", "V40", "V50", "V60"):
+        # Channel Selection
+        if msg_id in ("V10", "V20", "V30", "V40", "V50", "V60", "V70", "V80"):
             ch = int(msg_id[1])  # 'V10' -> 1, 'V60' -> 6
-            on = bool(int(val))
-            self.set_channel_display(ch, on)
+            self.set_channel_display(ch)
             return
 
         # Encoder 1 rotation => vertical position of current active channel


### PR DESCRIPTION
Channel connection flow:
Press channel, if disabled, enable and set as source. If enabled and set as source, disable, and set source as highest numbered enabled channel. If enabled but not the source, set as source. If all channels get disabled, the source is set to NONE.

This PR is ready with caveats:
- The improved source selection section has not been tested on the MSO
- The current channel state is NOT queried from the scope. The state from the Pi will override it. I'm not sure it's worth doing otherwise, as I assume we'll soon add state syncing from the scope.

I think it's fine to merge now, or we can wait until I can do a *complete* test on Mon/Tue.

Closes #12 