### PR TITLE
feat: Introduce WebSocket API

### DIFF
--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = ["Private :: Do Not Upload"]
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.135.1",
+    "loguru>=0.7.3",
     "pyserial>=3.5",
     "pyusb==1.3.1",
     "pyvisa==1.16.1",
@@ -29,6 +30,7 @@ Repository = "https://github.com/PSU-ECE-Capstone-11-2025-26/demo-repository.git
 build = [
     "setuptools>=80.9.0",
     "pytest>=9.0.2",
+    "httpx>=0.28.0",
 ]
 dev = [
     "ruff>=0.14.11",

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pyvisa==1.16.1",
     "pyvisa-py==0.8.1",
     "uvicorn>=0.41.0",
+    "websockets>=16.0",
 ]
 
 [project.urls]

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -14,10 +14,12 @@ license-files = ["../LICEN[CS]E*"]
 classifiers = ["Private :: Do Not Upload"]
 requires-python = ">=3.12"
 dependencies = [
+    "fastapi>=0.135.1",
     "pyserial>=3.5",
     "pyusb==1.3.1",
     "pyvisa==1.16.1",
     "pyvisa-py==0.8.1",
+    "uvicorn>=0.41.0",
 ]
 
 [project.urls]

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,8 +1,10 @@
+import threading
 import time
 
 import pyvisa
 from pyvisa.resources import MessageBasedResource
 
+from tekafp.api_server import run_api_server
 from tekafp.input import Input
 from tekafp.uart import UARTBridge
 from tekafp.util import clamp, parse_resp
@@ -243,7 +245,7 @@ class Controller:
         if msg_id == "AR0":
             self.toggle_run_stop()
             return
-        
+
         # Fast Acquire button
         if msg_id == "AF0":
             self.toggle_fast_acquire()
@@ -260,6 +262,9 @@ def main() -> None:
 
     bridge = connect_uart()
     controller = Controller(scope)
+    print("Starting WebSocket API thread...")
+    api_thead = threading.Thread(target=run_api_server, daemon=True)
+    api_thead.start()
 
     try:
         while True:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,12 +1,18 @@
 import threading
-import time
 
 import pyvisa
 from pyvisa.resources import MessageBasedResource
 
-from tekafp.api_server import get_packet, run_api_server, send_packet_data
+from tekafp.api_server import (
+    RawPacket,
+    get_raw_packet,
+    run_api_server,
+    send_packet_data,
+    startup_event,
+)
 from tekafp.api_server.packets import (
     MacroRecordPacketData,
+    PacketData,
     ScopeActionPacketData,
     ScopeListPacketData,
 )
@@ -244,7 +250,7 @@ def main() -> None:
     print("Starting WebSocket API thread...")
     api_thead = threading.Thread(target=run_api_server, daemon=True)
     api_thead.start()
-    time.sleep(1)  # wait a second for api thread to start
+    startup_event.wait()
 
     # ctrl setup
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
@@ -265,8 +271,9 @@ def main() -> None:
         print("Connected ctrl:", scope.query("*IDN?").strip())
         scopes[idn] = Controller(scope)
 
-    def handle_packet(packet: dict) -> None:
-        for data in packet["data"]:
+    def handle_packet(packet: RawPacket) -> None:
+        for pd in packet["data"]:
+            data = PacketData.decode(pd)
             match data:
                 case ScopeActionPacketData(action=a):
                     match a:
@@ -297,17 +304,18 @@ def main() -> None:
 
     try:
         while True:
-            if scopes:
-                raw = bridge.get()
-                if raw:
-                    try:
-                        inp = Input.from_bytes(raw)
-                    except Exception as e:
-                        print(f"Bad UART message {raw!r}: {e}")
-                        continue
-                    # TODO: iterate all scopes instead to control multiple at once
-                    list(scopes.values())[0].handle_input(inp)
-                handle_packet(get_packet())
+            raw = bridge.get()
+            if scopes and raw:
+                try:
+                    inp = Input.from_bytes(raw)
+                except Exception as e:
+                    print(f"Bad UART message {raw!r}: {e}")
+                    continue
+                # TODO: iterate all scopes instead to control multiple at once
+                list(scopes.values())[0].handle_input(inp)
+            new_packet = get_raw_packet()
+            if new_packet:
+                handle_packet(new_packet)
 
     except KeyboardInterrupt:
         print("\nExiting...")

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -4,8 +4,12 @@ import time
 import pyvisa
 from pyvisa.resources import MessageBasedResource
 
-from tekafp.api_server import PacketData, get_packet, run_api_server
-from tekafp.api_server.packets import MacroRecordPacketData, ScopeActionPacketData
+from tekafp.api_server import get_packet, run_api_server, send_packet_data
+from tekafp.api_server.packets import (
+    MacroRecordPacketData,
+    ScopeActionPacketData,
+    ScopeListPacketData,
+)
 from tekafp.input import Input
 from tekafp.uart import UARTBridge
 from tekafp.util import clamp, parse_resp
@@ -22,29 +26,6 @@ SCOPE_TIMEOUT_MS = 5000
 # Tuning knobs for “feel”
 VERT_STEP_DIVS = 0.10  # Vertical position step per encoder detent (+/-1)
 HORIZ_STEP_PCT = 1.0  # Horizontal position step in percent (0..~100) per detent
-
-
-def connect_scope() -> MessageBasedResource:
-    rm = pyvisa.ResourceManager(PYVISA_BACKEND)
-
-    while True:
-        resources = rm.list_resources()
-        usb = [r for r in resources if r.startswith("USB")]
-
-        if usb:
-            scope: MessageBasedResource = rm.open_resource(usb[0])
-            scope.timeout = SCOPE_TIMEOUT_MS
-            scope.write_termination = "\n"
-            scope.read_termination = "\n"
-
-            # Make sure we're in a mode where horizontal position behaves like the
-            # front panel knob
-            # delay mode OFF => HORizontal:POSition works like HORIZONTAL POSITION knob
-            scope.write("HORIZONTAL:DELAY:MODE OFF")
-            return scope
-
-        print("No USB scope found, retrying in 2s...")
-        time.sleep(2)
 
 
 def connect_uart() -> UARTBridge:
@@ -98,28 +79,6 @@ class Controller:
         print(
             f"[SCOPE] CH{channel} display -> {self._channels[channel]} (source={self._source_channel})"  # noqa: E501
         )
-
-    def handle_packet(self, packet: dict) -> None:
-        data: PacketData
-        for data in packet["data"]:
-            if isinstance(data, ScopeActionPacketData):
-                if data.action == "enable":
-                    pass
-                    # TODO: if no scope is saved, wait to enable controller
-                    # or bridge until a scope is enabled (and connected)
-                elif data.action == "disable":
-                    pass  # TODO
-                else:
-                    print("Invalid scope action")
-            elif isinstance(data, MacroRecordPacketData):
-                if data.record:
-                    pass
-                    # TODO record for slot data.slot
-                    # If a different slot is recording, stop that one first.
-                else:
-                    pass  # TODO stop recording for slot data.slot
-            else:
-                print(f"Unknown or incorrect packet type {data['$type']}")
 
     def adjust_vertical_position(self, detents: int) -> None:
         ch = self._source_channel
@@ -280,34 +239,81 @@ class Controller:
             return
 
 def main() -> None:
-    scope: MessageBasedResource = None
-    print("Connected scope:", scope.query("*IDN?").strip())
-
+    # internal setup
     bridge = connect_uart()
-    controller = Controller(scope)
     print("Starting WebSocket API thread...")
     api_thead = threading.Thread(target=run_api_server, daemon=True)
     api_thead.start()
-    time.sleep(1) # wait a second for api thread to start
+    time.sleep(1)  # wait a second for api thread to start
+
+    # ctrl setup
+    rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
+    scopes: dict[str, Controller] = {}
+
+    def connect_to_scope(idn: str) -> None:
+        scope: MessageBasedResource = rm.open_resource(
+            idn,
+            resource_pyclass=MessageBasedResource,
+            timeout=SCOPE_TIMEOUT_MS,
+            write_termination="\n",
+            read_termination="\n",
+        )
+        # Make sure we're in a mode where horizontal position behaves like the
+        # front panel knob
+        # delay mode OFF => HORizontal:POSition works like HORIZONTAL POSITION knob
+        scope.write("HORIZONTAL:DELAY:MODE OFF")
+        print("Connected ctrl:", scope.query("*IDN?").strip())
+        scopes[idn] = Controller(scope)
+
+    def handle_packet(packet: dict) -> None:
+        for data in packet["data"]:
+            match data:
+                case ScopeActionPacketData(action=a):
+                    match a:
+                        case "enable":
+                            if data.scope not in scopes:
+                                connect_to_scope(data.scope)
+                        case "disable":
+                            if data.scope in scopes:
+                                c = scopes.pop(data.scope)
+                                c.scope.close()
+                        case "list":
+                            send_packet_data(
+                                ScopeListPacketData(
+                                    rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")
+                                )
+                            )
+                        case _:
+                            print(f"Unknown action: {a}")
+                case MacroRecordPacketData():
+                    if data.record:
+                        pass
+                        # TODO record for slot data.slot
+                        # If a different slot is recording, stop that one first.
+                    else:
+                        pass  # TODO stop recording for slot data.slot
+                case _:
+                    print(f"Unknown or incorrect packet type {data.type}")
 
     try:
         while True:
-            raw = bridge.get()
-            if raw:
-                try:
-                    inp = Input.from_bytes(raw)
-                except Exception as e:
-                    print(f"Bad UART message {raw!r}: {e}")
-                    continue
-
-                controller.handle_input(inp)
-            for packet_data in get_packet():
-                controller.handle_packet(packet_data)
+            if scopes:
+                raw = bridge.get()
+                if raw:
+                    try:
+                        inp = Input.from_bytes(raw)
+                    except Exception as e:
+                        print(f"Bad UART message {raw!r}: {e}")
+                        continue
+                    # TODO: iterate all scopes instead to control multiple at once
+                    list(scopes.values())[0].handle_input(inp)
+                handle_packet(get_packet())
 
     except KeyboardInterrupt:
         print("\nExiting...")
     finally:
-        scope.close()
+        for ctrl in scopes.values():
+            ctrl.scope.close()
         bridge.close()
 
 

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,3 +1,4 @@
+import argparse
 import threading
 
 import pyvisa
@@ -17,7 +18,7 @@ from tekafp.api_server.packets import (
     ScopeListPacketData,
 )
 from tekafp.input import Input
-from tekafp.uart import UARTBridge
+from tekafp.uart import MockUARTBridge, UARTBridge
 from tekafp.util import clamp, parse_resp
 
 
@@ -34,7 +35,9 @@ VERT_STEP_DIVS = 0.10  # Vertical position step per encoder detent (+/-1)
 HORIZ_STEP_PCT = 1.0  # Horizontal position step in percent (0..~100) per detent
 
 
-def connect_uart() -> UARTBridge:
+def connect_uart(mock: bool = False) -> UARTBridge:
+    if mock:
+        return MockUARTBridge(PORT, baudrate=BAUD, timeout=1, write_timeout=1)
     bridge = UARTBridge(PORT, baudrate=BAUD, timeout=1, write_timeout=1)
     if not bridge.connect():
         raise RuntimeError(f"Failed to open UART on {PORT}")
@@ -245,8 +248,11 @@ class Controller:
             return
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mock", action="store_true", help="Run in mock mode")
+    args = parser.parse_args()
     # internal setup
-    bridge = connect_uart()
+    bridge = connect_uart(args.mock)
     print("Starting WebSocket API thread...")
     api_thead = threading.Thread(target=run_api_server, daemon=True)
     api_thead.start()
@@ -256,9 +262,9 @@ def main() -> None:
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
     scopes: dict[str, Controller] = {}
 
-    def connect_to_scope(idn: str) -> None:
+    def connect_to_scope(resource_name: str) -> None:
         scope: MessageBasedResource = rm.open_resource(
-            idn,
+            resource_name,
             resource_pyclass=MessageBasedResource,
             timeout=SCOPE_TIMEOUT_MS,
             write_termination="\n",
@@ -268,28 +274,48 @@ def main() -> None:
         # front panel knob
         # delay mode OFF => HORizontal:POSition works like HORIZONTAL POSITION knob
         scope.write("HORIZONTAL:DELAY:MODE OFF")
-        print("Connected ctrl:", scope.query("*IDN?").strip())
-        scopes[idn] = Controller(scope)
+        idn = scope.query("*IDN?").strip()
+        print("Connected ctrl:", idn)
+        scopes[resource_name] = Controller(scope)
 
     def handle_packet(packet: RawPacket) -> None:
         for pd in packet["data"]:
             data = PacketData.decode(pd)
             match data:
                 case ScopeActionPacketData(action=a):
+                    print(f"Received packet action='{a}'")
                     match a:
                         case "enable":
-                            if data.scope not in scopes:
+                            print(f"enabling scope {data.scope}")
+                            if not args.mock and data.scope not in scopes:
                                 connect_to_scope(data.scope)
                         case "disable":
+                            print(f"disabling scope {data.scope}")
+                            if args.mock:
+                                break
                             if data.scope in scopes:
                                 c = scopes.pop(data.scope)
                                 c.scope.close()
+                            else:
+                                print(f"scope {data.scope} not enabled: ignoring")
                         case "list":
-                            send_packet_data(
-                                ScopeListPacketData(
-                                    rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")
+                            if args.mock:
+                                send_packet_data(
+                                    ScopeListPacketData(
+                                        [
+                                            "USB0::0x0699::0x0363::C102912::INSTR",
+                                            "USB0::0x0699::0x0408::B011823::INSTR",
+                                        ]
+                                    )
                                 )
-                            )
+                            else:
+                                send_packet_data(
+                                    ScopeListPacketData(
+                                        rm.list_resources(
+                                            "(USB?*::INSTR|TCPIP?*::INSTR)"
+                                        )
+                                    )
+                                )
                         case _:
                             print(f"Unknown action: {a}")
                 case MacroRecordPacketData():
@@ -311,7 +337,7 @@ def main() -> None:
                 except Exception as e:
                     print(f"Bad UART message {raw!r}: {e}")
                     continue
-                # TODO: iterate all scopes instead to control multiple at once
+                # iterating all scopes here would allow control of multiple at once
                 list(scopes.values())[0].handle_input(inp)
             new_packet = get_raw_packet()
             if new_packet:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -4,7 +4,8 @@ import time
 import pyvisa
 from pyvisa.resources import MessageBasedResource
 
-from tekafp.api_server import get_packets, run_api_server
+from tekafp.api_server import PacketData, get_packet, run_api_server
+from tekafp.api_server.packets import MacroRecordPacketData, ScopeActionPacketData
 from tekafp.input import Input
 from tekafp.uart import UARTBridge
 from tekafp.util import clamp, parse_resp
@@ -99,7 +100,26 @@ class Controller:
         )
 
     def handle_packet(self, packet: dict) -> None:
-        pass
+        data: PacketData
+        for data in packet["data"]:
+            if isinstance(data, ScopeActionPacketData):
+                if data.action == "enable":
+                    pass
+                    # TODO: if no scope is saved, wait to enable controller
+                    # or bridge until a scope is enabled (and connected)
+                elif data.action == "disable":
+                    pass  # TODO
+                else:
+                    print("Invalid scope action")
+            elif isinstance(data, MacroRecordPacketData):
+                if data.record:
+                    pass
+                    # TODO record for slot data.slot
+                    # If a different slot is recording, stop that one first.
+                else:
+                    pass  # TODO stop recording for slot data.slot
+            else:
+                print(f"Unknown or incorrect packet type {data['$type']}")
 
     def adjust_vertical_position(self, detents: int) -> None:
         ch = self._source_channel
@@ -268,6 +288,7 @@ def main() -> None:
     print("Starting WebSocket API thread...")
     api_thead = threading.Thread(target=run_api_server, daemon=True)
     api_thead.start()
+    time.sleep(1) # wait a second for api thread to start
 
     try:
         while True:
@@ -280,7 +301,7 @@ def main() -> None:
                     continue
 
                 controller.handle_input(inp)
-            for packet_data in get_packets():
+            for packet_data in get_packet():
                 controller.handle_packet(packet_data)
 
     except KeyboardInterrupt:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -4,7 +4,7 @@ import time
 import pyvisa
 from pyvisa.resources import MessageBasedResource
 
-from tekafp.api_server import run_api_server
+from tekafp.api_server import get_packets, run_api_server
 from tekafp.input import Input
 from tekafp.uart import UARTBridge
 from tekafp.util import clamp, parse_resp
@@ -98,6 +98,9 @@ class Controller:
             f"[SCOPE] CH{channel} display -> {self._channels[channel]} (source={self._source_channel})"  # noqa: E501
         )
 
+    def handle_packet(self, packet: dict) -> None:
+        pass
+
     def adjust_vertical_position(self, detents: int) -> None:
         ch = self._source_channel
         cur = float(self.scope.query(f"CH{ch}:POSITION?").strip().split()[-1])
@@ -161,7 +164,7 @@ class Controller:
             self.scope.write("ACQUIRE:STATE RUN")
             print("[SCOPE] Run/Stop -> RUN")
             return
-        
+
     # Run the scope's AutoSet feature
     def autoset(self) -> None:
         self.scope.write("AUTOSET EXECUTE")
@@ -257,7 +260,7 @@ class Controller:
             return
 
 def main() -> None:
-    scope: MessageBasedResource = connect_scope()
+    scope: MessageBasedResource = None
     print("Connected scope:", scope.query("*IDN?").strip())
 
     bridge = connect_uart()
@@ -277,6 +280,8 @@ def main() -> None:
                     continue
 
                 controller.handle_input(inp)
+            for packet_data in get_packets():
+                controller.handle_packet(packet_data)
 
     except KeyboardInterrupt:
         print("\nExiting...")

--- a/software/tekafp/api_server/__init__.py
+++ b/software/tekafp/api_server/__init__.py
@@ -1,18 +1,30 @@
 import asyncio
+from contextlib import asynccontextmanager
 from queue import Empty, Queue, ShutDown
+import threading
+from typing import AsyncGenerator, Generator
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 import uvicorn
 
-from tekafp.api_server.packets import PacketData
+from .packets import PacketData, RawPacket
 
 
-app = FastAPI()
+startup_event = threading.Event()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
+    startup_event.set()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 app.state.send_queue = Queue()
 app.state.receive_queue = Queue()
 
 
-def get_packet() -> dict:
+def get_raw_packet() -> dict:
     """Get a packet from the queue.
     :return: A packet
     :rtype: dict

--- a/software/tekafp/api_server/__init__.py
+++ b/software/tekafp/api_server/__init__.py
@@ -1,8 +1,7 @@
 import asyncio
-from queue import Queue, ShutDown
+from queue import Empty, Queue, ShutDown
 
-from fastapi import FastAPI
-from starlette.websockets import WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 import uvicorn
 
 from tekafp.api_server.packets import PacketData
@@ -16,12 +15,12 @@ app.state.receive_queue = Queue()
 def get_packet() -> dict:
     """Get a packet from the queue.
     :return: A packet
-    :rtype: Generator[PacketData, None, None]
+    :rtype: dict
     """
-    packet = app.state.receive_queue.get()
-    for data in packet["data"]:
-        cls = PacketData.REGISTRY[data["$type"]]
-        yield cls.from_dict(data)
+    try:
+        return app.state.receive_queue.get_nowait()
+    except Empty:
+        return {}
 
 
 def send_packet_data(data: PacketData) -> None:

--- a/software/tekafp/api_server/__init__.py
+++ b/software/tekafp/api_server/__init__.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+from starlette.websockets import WebSocket
+import uvicorn
+
+from tekafp.api_server.packets import BY_TYPE
+
+
+async def decode_packet(packet: dict) -> None:
+    for data in packet.values():
+        BY_TYPE[data["$type"]](data)
+app = FastAPI()
+
+def run_api_server() -> None:
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+    while True:
+        data = await websocket.receive_json()
+        await decode_packet(data)
+        await websocket.send_json(data)

--- a/software/tekafp/api_server/__init__.py
+++ b/software/tekafp/api_server/__init__.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from starlette.websockets import WebSocket, WebSocketDisconnect
 import uvicorn
 
-from tekafp.api_server.packets import BY_TYPE
+from tekafp.api_server.packets import PacketData
 
 
 app = FastAPI()
@@ -13,15 +13,25 @@ app.state.send_queue = Queue()
 app.state.receive_queue = Queue()
 
 
-def get_packets() -> dict:
+def get_packet() -> dict:
+    """Get a packet from the queue.
+    :return: A packet
+    :rtype: Generator[PacketData, None, None]
+    """
     packet = app.state.receive_queue.get()
-    for data in packet.values():
-        yield BY_TYPE[data["$type"]](data)
+    for data in packet["data"]:
+        cls = PacketData.REGISTRY[data["$type"]]
+        yield cls.from_dict(data)
 
 
-def send_packet(packet: dict) -> None:
+def send_packet_data(data: PacketData) -> None:
+    """Send packet data to the server
+
+    :param data: The packet data to send
+    :type data: PacketData
+    """
     try:
-        app.state.send_queue.put(packet)
+        app.state.send_queue.put(data.to_dict())
     except ShutDown:
         return  # TODO: log warning
 
@@ -41,10 +51,13 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     async def send() -> None:
         while True:
-            packet = await asyncio.to_thread(
+            packet_data = await asyncio.to_thread(
                 websocket.app.state.send_queue.get, timeout=0.5
             )
-            await websocket.send_json(packet)
+            items = [packet_data]
+            while not websocket.app.state.send_queue.empty():
+                items.append(websocket.app.state.send_queue.get_nowait())
+            await websocket.send_json({"from": "server", "data": items})
 
     receive_task = asyncio.create_task(receive())
     send_task = asyncio.create_task(send())

--- a/software/tekafp/api_server/__init__.py
+++ b/software/tekafp/api_server/__init__.py
@@ -2,12 +2,12 @@ import asyncio
 from contextlib import asynccontextmanager
 from queue import Empty, Queue, ShutDown
 import threading
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 import uvicorn
 
-from .packets import PacketData, RawPacket
+from .packets import PacketData, RawPacket  # noqa: F401
 
 
 startup_event = threading.Event()
@@ -62,13 +62,16 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     async def send() -> None:
         while True:
-            packet_data = await asyncio.to_thread(
-                websocket.app.state.send_queue.get, timeout=0.5
-            )
+            try:
+                packet_data = await asyncio.to_thread(
+                    websocket.app.state.send_queue.get, timeout=0.5
+                )
+            except Empty:
+                continue
             items = [packet_data]
             while not websocket.app.state.send_queue.empty():
                 items.append(websocket.app.state.send_queue.get_nowait())
-            await websocket.send_json({"from": "server", "data": items})
+            await websocket.send_json({"origin": "server", "data": items})
 
     receive_task = asyncio.create_task(receive())
     send_task = asyncio.create_task(send())

--- a/software/tekafp/api_server/__init__.py
+++ b/software/tekafp/api_server/__init__.py
@@ -1,22 +1,55 @@
+import asyncio
+from queue import Queue, ShutDown
+
 from fastapi import FastAPI
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketDisconnect
 import uvicorn
 
 from tekafp.api_server.packets import BY_TYPE
 
 
-async def decode_packet(packet: dict) -> None:
-    for data in packet.values():
-        BY_TYPE[data["$type"]](data)
 app = FastAPI()
+app.state.send_queue = Queue()
+app.state.receive_queue = Queue()
+
+
+def get_packets() -> dict:
+    packet = app.state.receive_queue.get()
+    for data in packet.values():
+        yield BY_TYPE[data["$type"]](data)
+
+
+def send_packet(packet: dict) -> None:
+    try:
+        app.state.send_queue.put(packet)
+    except ShutDown:
+        return  # TODO: log warning
+
 
 def run_api_server() -> None:
     uvicorn.run(app, host="0.0.0.0", port=8000)
 
+
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket) -> None:
     await websocket.accept()
-    while True:
-        data = await websocket.receive_json()
-        await decode_packet(data)
-        await websocket.send_json(data)
+
+    async def receive() -> None:
+        while True:
+            data = await websocket.receive_json()
+            websocket.app.state.receive_queue.put(data)
+
+    async def send() -> None:
+        while True:
+            packet = await asyncio.to_thread(
+                websocket.app.state.send_queue.get, timeout=0.5
+            )
+            await websocket.send_json(packet)
+
+    receive_task = asyncio.create_task(receive())
+    send_task = asyncio.create_task(send())
+    try:
+        await asyncio.gather(receive_task, send_task)
+    except WebSocketDisconnect:
+        receive_task.cancel()
+        send_task.cancel()

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, field, fields
 from typing import ClassVar, TypedDict
 
 
@@ -8,13 +8,14 @@ class RawPacket(TypedDict):
 
 @dataclass
 class PacketData:
-    REGISTRY: ClassVar[dict[str, type["PacketData"]]] = {}
-    type: str
+    _registry: ClassVar[dict[str, type["PacketData"]]] = {}
+    type: ClassVar[str] = ""
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
         name = cls.__name__.removesuffix("PacketData")
-        cls.REGISTRY[name] = cls
+        cls.type = name
+        cls._registry[name] = cls
 
     @classmethod
     def from_dict(cls, data: dict) -> "PacketData":
@@ -23,11 +24,11 @@ class PacketData:
 
     @classmethod
     def decode(cls, data: dict) -> "PacketData":
-        subclass = cls.REGISTRY[data["type"]]
+        subclass = cls._registry[data["type"]]
         return subclass.from_dict(data)
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        return {"type": self.type, **asdict(self)}
 
 
 @dataclass

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 @dataclass
 class PacketData:
     REGISTRY: ClassVar[dict[str, type["PacketData"]]] = {}
+    type: str
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -1,0 +1,38 @@
+from typing import Required, TypedDict
+
+
+class MacroRecordPacketData(TypedDict):
+    record: Required[bool]
+    slot: Required[int]
+
+class MacroStatePacketData(TypedDict):
+    macros: Required[list[bool]]
+
+class ScopeActionPacketData(TypedDict):
+    action: Required[str]
+    scope: Required[str]
+
+class ScopeInfoPacketData(TypedDict):
+    channel_count: Required[int]
+
+class ScopeListPacketData(TypedDict):
+    scopes: Required[list[str]]
+
+class ScopeStatePacketData(TypedDict):
+    status: Required[str]
+    channels: Required[list[bool]]
+    source_channel: Required[int]
+    trigger_source: Required[int]
+    trigger_mode: Required[str]
+    trigger_edge_slope: Required[str]
+    run_stop: Required[bool]
+    zoom_enabled: Required[bool]
+
+BY_TYPE: dict[str, type[TypedDict]] = {
+    "ScopeState": ScopeStatePacketData,
+    "ScopeList": ScopeListPacketData,
+    "ScopeAction": ScopeActionPacketData,
+    "ScopeInfo": ScopeInfoPacketData,
+    "MacroRecord": MacroRecordPacketData,
+    "MacroState": MacroStatePacketData,
+}

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -1,6 +1,10 @@
 from dataclasses import asdict, dataclass, fields
-from typing import ClassVar
+from typing import ClassVar, TypedDict
 
+
+class RawPacket(TypedDict):
+    origin: str
+    data: list[dict]
 
 @dataclass
 class PacketData:
@@ -17,14 +21,13 @@ class PacketData:
         field_names = {f.name for f in fields(cls)}
         return cls(**{k: v for k, v in data.items() if k in field_names})
 
+    @classmethod
+    def decode(cls, data: dict) -> "PacketData":
+        subclass = cls.REGISTRY[data["type"]]
+        return subclass.from_dict(data)
+
     def to_dict(self) -> dict:
         return asdict(self)
-
-
-@dataclass
-class PacketContainer:
-    From: str
-    Data: list[PacketData]
 
 
 @dataclass

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -1,38 +1,65 @@
-from typing import Required, TypedDict
+from dataclasses import asdict, dataclass, fields
+from typing import ClassVar
 
 
-class MacroRecordPacketData(TypedDict):
-    record: Required[bool]
-    slot: Required[int]
+@dataclass
+class PacketData:
+    REGISTRY: ClassVar[dict[str, type["PacketData"]]] = {}
 
-class MacroStatePacketData(TypedDict):
-    macros: Required[list[bool]]
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        name = cls.__name__.removesuffix("PacketData")
+        cls.REGISTRY[name] = cls
 
-class ScopeActionPacketData(TypedDict):
-    action: Required[str]
-    scope: Required[str]
+    @classmethod
+    def from_dict(cls, data: dict) -> "PacketData":
+        field_names = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in field_names})
 
-class ScopeInfoPacketData(TypedDict):
-    channel_count: Required[int]
+    def to_dict(self) -> dict:
+        return asdict(self)
 
-class ScopeListPacketData(TypedDict):
-    scopes: Required[list[str]]
 
-class ScopeStatePacketData(TypedDict):
-    status: Required[str]
-    channels: Required[list[bool]]
-    source_channel: Required[int]
-    trigger_source: Required[int]
-    trigger_mode: Required[str]
-    trigger_edge_slope: Required[str]
-    run_stop: Required[bool]
-    zoom_enabled: Required[bool]
+@dataclass
+class PacketContainer:
+    From: str
+    Data: list[PacketData]
 
-BY_TYPE: dict[str, type[TypedDict]] = {
-    "ScopeState": ScopeStatePacketData,
-    "ScopeList": ScopeListPacketData,
-    "ScopeAction": ScopeActionPacketData,
-    "ScopeInfo": ScopeInfoPacketData,
-    "MacroRecord": MacroRecordPacketData,
-    "MacroState": MacroStatePacketData,
-}
+
+@dataclass
+class MacroRecordPacketData(PacketData):
+    record: bool
+    slot: int
+
+
+@dataclass
+class MacroStatePacketData(PacketData):
+    macros: list[bool]
+
+
+@dataclass
+class ScopeActionPacketData(PacketData):
+    action: str
+    scope: str
+
+
+@dataclass
+class ScopeInfoPacketData(PacketData):
+    channel_count: int
+
+
+@dataclass
+class ScopeListPacketData(PacketData):
+    scopes: list[str]
+
+
+@dataclass
+class ScopeStatePacketData(PacketData):
+    status: str
+    channels: list[bool]
+    source_channel: int
+    trigger_source: int
+    trigger_mode: str
+    trigger_edge_slope: str
+    run_stop: bool
+    zoom_enabled: bool

--- a/software/tekafp/uart/__init__.py
+++ b/software/tekafp/uart/__init__.py
@@ -98,7 +98,8 @@ class UARTBridge:
         self._queue.shutdown()
         self._queue.join()
         self._thread.join()
-        self.serial.close()
+        if self.serial:
+            self.serial.close()
 
     def get(self, timeout: Optional[float] = None) -> Optional[bytes]:
         """
@@ -149,3 +150,20 @@ class UARTBridge:
             return True
         except serial.SerialTimeoutException:
             return False
+
+
+class MockUARTBridge(UARTBridge):
+    def connect(self) -> bool:
+        return True
+
+    def queue_write(self, data: bytes) -> None:
+        pass
+
+    def write_sync(self, data: bytes) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+    def get(self, timeout: Optional[float] = None) -> Optional[bytes]:
+        return b"V10"

--- a/software/test/api_server/test_packets.py
+++ b/software/test/api_server/test_packets.py
@@ -20,6 +20,7 @@ SAMPLE_DATA = [
     (
         ScopeStatePacketData,
         {
+            "type": "ScopeState",
             "status": "connected",
             "channels": [False, False, False, True],
             "source_channel": 0,

--- a/software/test/api_server/test_packets.py
+++ b/software/test/api_server/test_packets.py
@@ -1,0 +1,65 @@
+import pytest
+
+from tekafp.api_server.packets import (
+    MacroRecordPacketData,
+    MacroStatePacketData,
+    PacketData,
+    ScopeActionPacketData,
+    ScopeInfoPacketData,
+    ScopeListPacketData,
+    ScopeStatePacketData,
+)
+
+
+SAMPLE_DATA = [
+    (MacroRecordPacketData, {"record": True, "slot": 2}),
+    (MacroStatePacketData, {"macros": [True, False, True, False]}),
+    (ScopeActionPacketData, {"action": "enable", "scope": "USB0::::::::INSTR"}),
+    (ScopeInfoPacketData, {"channel_count": 8}),
+    (ScopeListPacketData, {"scopes": ["USB0::A::INSTR", "USB0::B::INSTR"]}),
+    (
+        ScopeStatePacketData,
+        {
+            "status": "connected",
+            "channels": [False, False, False, True],
+            "source_channel": 0,
+            "trigger_source": 0,
+            "trigger_mode": "AUTO",
+            "trigger_edge_slope": "RISE",
+            "run_stop": True,
+            "zoom_enabled": False,
+        },
+    ),
+]
+
+
+def test_registry_keys() -> None:
+    expected = {"MacroRecord", "MacroState", "ScopeAction", "ScopeInfo", "ScopeList", "ScopeState"}
+    assert set(PacketData.REGISTRY.keys()) == expected
+
+
+@pytest.mark.parametrize(("cls", "data"), SAMPLE_DATA)
+def test_from_dict(cls: type[PacketData], data: dict) -> None:
+    pkt = cls.from_dict(data)
+    for key, value in data.items():
+        assert getattr(pkt, key) == value
+
+
+@pytest.mark.parametrize(("cls", "data"), SAMPLE_DATA)
+def test_to_dict(cls: type[PacketData], data: dict) -> None:
+    pkt = cls(**data)
+    assert pkt.to_dict() == data
+
+
+@pytest.mark.parametrize(("cls", "data"), SAMPLE_DATA)
+def test_roundtrip(cls: type[PacketData], data: dict) -> None:
+    original = cls(**data)
+    reconstructed = cls.from_dict(original.to_dict())
+    assert original == reconstructed
+
+
+def test_from_dict_ignores_extra_keys() -> None:
+    data = {"$type": "ScopeInfo", "channel_count": 4, "extra": "ignored"}
+    pkt = ScopeInfoPacketData.from_dict(data)
+    assert pkt.channel_count == 4
+    assert not hasattr(pkt, "extra")

--- a/software/test/api_server/test_packets.py
+++ b/software/test/api_server/test_packets.py
@@ -12,11 +12,11 @@ from tekafp.api_server.packets import (
 
 
 SAMPLE_DATA = [
-    (MacroRecordPacketData, {"record": True, "slot": 2}),
-    (MacroStatePacketData, {"macros": [True, False, True, False]}),
-    (ScopeActionPacketData, {"action": "enable", "scope": "USB0::::::::INSTR"}),
-    (ScopeInfoPacketData, {"channel_count": 8}),
-    (ScopeListPacketData, {"scopes": ["USB0::A::INSTR", "USB0::B::INSTR"]}),
+    (MacroRecordPacketData, {"type": "MacroRecord", "record": True, "slot": 2}),
+    (MacroStatePacketData, {"type": "MacroState", "macros": [True, False, True, False]}),
+    (ScopeActionPacketData, {"type": "ScopeAction", "action": "enable", "scope": "USB0::::::::INSTR"}),
+    (ScopeInfoPacketData, {"type": "ScopeInfo", "channel_count": 8}),
+    (ScopeListPacketData, {"type": "ScopeList", "scopes": ["USB0::A::INSTR", "USB0::B::INSTR"]}),
     (
         ScopeStatePacketData,
         {
@@ -60,7 +60,7 @@ def test_roundtrip(cls: type[PacketData], data: dict) -> None:
 
 
 def test_from_dict_ignores_extra_keys() -> None:
-    data = {"$type": "ScopeInfo", "channel_count": 4, "extra": "ignored"}
+    data = {"type": "ScopeInfo", "channel_count": 4, "extra": "ignored"}
     pkt = ScopeInfoPacketData.from_dict(data)
     assert pkt.channel_count == 4
     assert not hasattr(pkt, "extra")

--- a/software/test/api_server/test_packets.py
+++ b/software/test/api_server/test_packets.py
@@ -36,7 +36,7 @@ SAMPLE_DATA = [
 
 def test_registry_keys() -> None:
     expected = {"MacroRecord", "MacroState", "ScopeAction", "ScopeInfo", "ScopeList", "ScopeState"}
-    assert set(PacketData.REGISTRY.keys()) == expected
+    assert set(PacketData._registry.keys()) == expected
 
 
 @pytest.mark.parametrize(("cls", "data"), SAMPLE_DATA)
@@ -48,13 +48,13 @@ def test_from_dict(cls: type[PacketData], data: dict) -> None:
 
 @pytest.mark.parametrize(("cls", "data"), SAMPLE_DATA)
 def test_to_dict(cls: type[PacketData], data: dict) -> None:
-    pkt = cls(**data)
+    pkt = cls(**{k: v for k, v in data.items() if k != "type"})
     assert pkt.to_dict() == data
 
 
 @pytest.mark.parametrize(("cls", "data"), SAMPLE_DATA)
 def test_roundtrip(cls: type[PacketData], data: dict) -> None:
-    original = cls(**data)
+    original = cls(**{k: v for k, v in data.items() if k != "type"})
     reconstructed = cls.from_dict(original.to_dict())
     assert original == reconstructed
 

--- a/software/test/api_server/test_websocket.py
+++ b/software/test/api_server/test_websocket.py
@@ -10,13 +10,6 @@ SCOPE_ACTION_PACKET = {
     ],
 }
 
-MACRO_RECORD_PACKET = {
-    "from": "client",
-    "data": [
-        {"$type": "MacroRecord", "record": True, "slot": 0},
-    ],
-}
-
 SCOPE_STATE_PACKET = {
     "from": "server",
     "data": [
@@ -49,10 +42,9 @@ def test_websocket_receive() -> None:
 def test_websocket_send() -> None:
     """Items in the send queue are forwarded to the client."""
     client = TestClient(app)
-    app.state.send_queue.put(SCOPE_STATE_PACKET)
+    app.state.send_queue.put(SCOPE_STATE_PACKET["data"][0])
 
     with client.websocket_connect("/ws") as ws:
-        ws.send_json(MACRO_RECORD_PACKET)
         data = ws.receive_json()
 
     assert data == SCOPE_STATE_PACKET

--- a/software/test/api_server/test_websocket.py
+++ b/software/test/api_server/test_websocket.py
@@ -4,14 +4,14 @@ from tekafp.api_server import app
 
 
 SCOPE_ACTION_PACKET = {
-    "from": "client",
+    "origin": "client",
     "data": [
         {"type": "ScopeAction", "action": "enable", "scope": "USB0::::::::INSTR"},
     ],
 }
 
 SCOPE_STATE_PACKET = {
-    "from": "server",
+    "origin": "server",
     "data": [
         {
             "type": "ScopeState",

--- a/software/test/api_server/test_websocket.py
+++ b/software/test/api_server/test_websocket.py
@@ -6,7 +6,7 @@ from tekafp.api_server import app
 SCOPE_ACTION_PACKET = {
     "from": "client",
     "data": [
-        {"$type": "ScopeAction", "action": "enable", "scope": "USB0::::::::INSTR"},
+        {"type": "ScopeAction", "action": "enable", "scope": "USB0::::::::INSTR"},
     ],
 }
 
@@ -14,7 +14,7 @@ SCOPE_STATE_PACKET = {
     "from": "server",
     "data": [
         {
-            "$type": "ScopeState",
+            "type": "ScopeState",
             "status": "connected",
             "channels": [False, False, False, True],
             "source_channel": 0,

--- a/software/test/api_server/test_websocket.py
+++ b/software/test/api_server/test_websocket.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+
+from tekafp.api_server import app
+
+
+SCOPE_ACTION_PACKET = {
+    "from": "client",
+    "data": [
+        {"$type": "ScopeAction", "action": "enable", "scope": "USB0::::::::INSTR"},
+    ],
+}
+
+MACRO_RECORD_PACKET = {
+    "from": "client",
+    "data": [
+        {"$type": "MacroRecord", "record": True, "slot": 0},
+    ],
+}
+
+SCOPE_STATE_PACKET = {
+    "from": "server",
+    "data": [
+        {
+            "$type": "ScopeState",
+            "status": "connected",
+            "channels": [False, False, False, True],
+            "source_channel": 0,
+            "trigger_source": 0,
+            "trigger_mode": "AUTO",
+            "trigger_edge_slope": "RISE",
+            "run_stop": True,
+            "zoom_enabled": False,
+        },
+    ],
+}
+
+
+def test_websocket_receive() -> None:
+    """Client-sent JSON is placed into the receive queue."""
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json(SCOPE_ACTION_PACKET)
+
+    queued = app.state.receive_queue.get(timeout=1)
+    assert queued == SCOPE_ACTION_PACKET
+
+
+def test_websocket_send() -> None:
+    """Items in the send queue are forwarded to the client."""
+    client = TestClient(app)
+    app.state.send_queue.put(SCOPE_STATE_PACKET)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json(MACRO_RECORD_PACKET)
+        data = ws.receive_json()
+
+    assert data == SCOPE_STATE_PACKET

--- a/software/uv.lock
+++ b/software/uv.lock
@@ -173,6 +173,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -209,6 +237,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -615,6 +656,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "loguru" },
     { name = "pyserial" },
     { name = "pyusb" },
     { name = "pyvisa" },
@@ -624,6 +666,7 @@ dependencies = [
 
 [package.dev-dependencies]
 build = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "setuptools" },
 ]
@@ -636,6 +679,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyusb", specifier = "==1.3.1" },
     { name = "pyvisa", specifier = "==1.16.1" },
@@ -645,6 +689,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 build = [
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "setuptools", specifier = ">=80.9.0" },
 ]
@@ -720,4 +765,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]

--- a/software/uv.lock
+++ b/software/uv.lock
@@ -662,6 +662,7 @@ dependencies = [
     { name = "pyvisa" },
     { name = "pyvisa-py" },
     { name = "uvicorn" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -685,6 +686,7 @@ requires-dist = [
     { name = "pyvisa", specifier = "==1.16.1" },
     { name = "pyvisa-py", specifier = "==0.8.1" },
     { name = "uvicorn", specifier = ">=0.41.0" },
+    { name = "websockets", specifier = ">=16.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -765,6 +767,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]

--- a/software/uv.lock
+++ b/software/uv.lock
@@ -12,6 +12,37 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -87,6 +118,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -102,6 +145,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -222,6 +290,92 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
@@ -443,14 +597,29 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "tek-afp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "pyserial" },
     { name = "pyusb" },
     { name = "pyvisa" },
     { name = "pyvisa-py" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -466,10 +635,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.135.1" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyusb", specifier = "==1.3.1" },
     { name = "pyvisa", specifier = "==1.16.1" },
     { name = "pyvisa-py", specifier = "==0.8.1" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -518,10 +689,35 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]


### PR DESCRIPTION
This PR adds a FastAPI-based WebSocket API to tek-afp . This includes:

- JSON packet encode/decode
- FastAPI app, running in a separate thread, with uvicorn
- Bidirectional, asynchronous WebSocket endpoint
- Sending scope resource lists to the UI via `ScopeListPacketData`
- Enable/disable scopes from the UI via `ScopeActionPacketData`
- Unit tests

Other goodies needed to do all that:

- Argparse with `-m` flag: enable mock mode
- `MockUARTBridge` for mocking the UART without needing hardware
- Don't connect to real scopes and send dummy data to the UI if mock is enabled

Executing the rest of the packets will come in subsequent PRs. I don't want this one to get any bigger.

Closes #33 