### PR TITLE
Channel indicator commands

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -80,6 +80,8 @@ class Controller:
         self.scope: MessageBasedResource = scope
         self.bridge: UARTBridge = bridge 
 
+        self._sync_index: int = 1
+
         self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
         self._source_channel: int = 0
         self._vert_fine: bool = False # fine mode toggle for vertical scale
@@ -88,30 +90,40 @@ class Controller:
         resp = self.scope.query(f"DISPLAY:GLOBAL:CH{channel}:STATE?").strip().upper()
         return resp.endswith("1") or resp.endswith("ON")
 
-    def sync_channels_from_scope(self) -> None:
-        changed = False
-
+    def sync_all_channels_from_scope(self) -> None:
         for ch in range(1, 9):
             actual = self.get_scope_channel_state(ch)
-            if self._channels[ch] != actual:
-                self._channels[ch] = actual
-                self.send_channel_led(ch, actual)
-                changed = True
-                print(f"[SYNC] CH{ch} -> {actual}")
+            self._channels[ch] = actual
+            self.send_channel_led(ch, actual)
+            print(f"[SYNC] CH{ch} -> {actual}")
 
-        # Keep selected source sane if current source is now off
-        if self._source_channel != 0 and not self._channels[self._source_channel]:
-            highest = 0
-            for k, v in self._channels.items():
-                if v:
-                    highest = k
-            self._source_channel = highest
+    def sync_channels_from_scope(self) -> None:
+        ch = self._sync_index
 
-            if changed:
+        actual = self.get_scope_channel_state(ch)
+        if self._channels[ch] != actual:
+            self._channels[ch] = actual
+            self.send_channel_led(ch, actual)
+            print(f"[SYNC] CH{ch} -> {actual}")
+
+            # Keep selected source sane if current source is now off
+            if self._source_channel != 0 and not self._channels[self._source_channel]:
+                highest = 0
+                for k, v in self._channels.items():
+                    if v:
+                        highest = k
+                self._source_channel = highest
+
+                # Always write, not just when changed, to ensure source updates if it was changed externally
                 if self._source_channel == 0:
                     self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
                 else:
                     self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+        self._sync_index += 1
+        if self._sync_index > 8:
+            self._sync_index = 1
+
 
     def send_channel_led(self, channel: int, state: bool) -> None:
         # Send indicator update back to Pico
@@ -468,6 +480,7 @@ def main() -> None:
 
     try:
         last_sync = time.monotonic()
+        last_input = 0.0 # no input yet
         sync_period_s = 0.05
         while True:
             raw = bridge.get()
@@ -477,15 +490,20 @@ def main() -> None:
                 except Exception as e:
                     print(f"Bad UART message {raw!r}: {e}")
                     continue
+
                 # iterating all scopes here would allow control of multiple at once
-                list(scopes.values())[0].handle_input(inp)
+                ctrl = list(scopes.values())[0]
+                ctrl.handle_input(inp)
+                last_input = time.monotonic()
+
             new_packet = get_raw_packet()
             if new_packet:
                 handle_packet(new_packet)
 
             now = time.monotonic()
-            if scopes and now - last_sync > sync_period_s:
-                list(scopes.values())[0].sync_channels_from_scope()
+            if scopes and now - last_sync > sync_period_s and now - last_input > 0.1:
+                ctrl = list(scopes.values())[0]
+                ctrl.sync_channels_from_scope()
                 last_sync = now
 
     except KeyboardInterrupt:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -120,7 +120,7 @@ class Controller:
 
         msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
         self.bridge.queue_write(msg)
-        print(f"[UART]->PICO] {msg.decode().strip()}")
+        print(f"[UART->PICO] {msg.decode().strip()}")
 
     def sync_all_channel_leds(self) -> None:
         for ch in range(1,9):

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -415,7 +415,9 @@ def main() -> None:
         scope.write("HORIZONTAL:DELAY:MODE OFF")
         idn = scope.query("*IDN?").strip()
         print("Connected ctrl:", idn)
-        scopes[resource_name] = Controller(scope, bridge)
+        ctrl = Controller(scope, bridge)
+        ctrl.sync_channels_from_scope()
+        scopes[resource_name] = ctrl
 
     def handle_packet(packet: RawPacket) -> None:
         for pd in packet["data"]:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -107,10 +107,11 @@ class Controller:
                     highest = k
             self._source_channel = highest
 
-            if changed and self._source_channel == 0:
-                self.scope.write(f"DISPLAY:SELECT:SOURCE:NONE")
-            elif changed:
-                self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+            if changed:
+                if self._source_channel == 0:
+                    self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
+                else:
+                    self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
 
     def send_channel_led(self, channel: int, state: bool) -> None:
         # Send indicator update back to Pico

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -80,6 +80,8 @@ class Controller:
         self.scope: MessageBasedResource = scope
         self.bridge: UARTBridge = bridge 
 
+        self._sync_index: int = 1
+
         self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
         self._source_channel: int = 0
         self._vert_fine: bool = False # fine mode toggle for vertical scale
@@ -89,25 +91,11 @@ class Controller:
         return resp.endswith("1") or resp.endswith("ON")
 
     def sync_all_channels_from_scope(self) -> None:
-        highest = 0
-
         for ch in range(1, 9):
             actual = self.get_scope_channel_state(ch)
             self._channels[ch] = actual
             self.send_channel_led(ch, actual)
-            if actual:
-                highest = ch
-            print(f"[INIT] CH{ch} -> {actual}")
-
-        # Chooses highest enabled channel as the acive selected channel
-        self._source_channel = highest
-
-        if self._source_channel == 0:
-            self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
-        else:
-            self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
-
-        self.send_selected_channel_leds()
+            print(f"[SYNC] CH{ch} -> {actual}")
 
     def sync_all_changed_channels_from_scope(self) -> None:
         any_changed = False
@@ -119,11 +107,6 @@ class Controller:
                 self.send_channel_led(ch, actual)
                 print(f"[SYNC] CH{ch} -> {actual}")
                 any_changed = True
-
-                if actual:
-                    self._source_channel = ch
-                    self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
-                    self.send_selected_channel_leds()
 
         # Keep selected source sane if current source is now off
         if self._source_channel != 0 and not self._channels[self._source_channel]:
@@ -139,25 +122,55 @@ class Controller:
             else:
                 self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
 
-            self.send_selected_channel_leds()
-
         # If nothing changed, stay quiet
         if any_changed:
             print("[SYNC] Full channel sync pass complete")
 
 
-    # Per-channel RGB color (R,G,B)
-    CHANNEL_COLORS: dict[int, tuple[int, int, int]] = {
-        1: (1, 1, 0), # Yellow
-        2: (0, 1, 1), # Cyan
-        3: (1, 0, 0), # Red
-        4: (0, 1, 0), # Lime Green
-        5: (1, 1, 0), # Orange approximation 
-        6: (0, 0, 1), # Blue
-        7: (1, 0, 1), # Purple
-        8: (0, 1, 0), # Forest Green approximation
-    }
+    def sync_channels_from_scope(self) -> None:
+        ch = self._sync_index
 
+        actual = self.get_scope_channel_state(ch)
+        if self._channels[ch] != actual:
+            self._channels[ch] = actual
+            self.send_channel_led(ch, actual)
+            print(f"[SYNC] CH{ch} -> {actual}")
+
+            # Keep selected source sane if current source is now off
+            if self._source_channel != 0 and not self._channels[self._source_channel]:
+                highest = 0
+                for k, v in self._channels.items():
+                    if v:
+                        highest = k
+                self._source_channel = highest
+
+                # Always write, not just when changed, to ensure source updates if it was changed externally
+                if self._source_channel == 0:
+                    self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
+                else:
+                    self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+        self._sync_index += 1
+        if self._sync_index > 8:
+            self._sync_index = 1
+
+
+    def send_channel_led(self, channel: int, state: bool) -> None:
+        # Send indicator update back to Pico
+        if channel not in range(1,9):
+            return
+
+        # Per-channel RGB color (R,G,B)
+        channel_colors: dict[int, tuple[int, int, int]] = {
+            1: (1, 1, 0), # Yellow
+            2: (0, 1, 1), # Cyan
+            3: (1, 0, 0), # Red
+            4: (0, 1, 0), # Lime Green
+            5: (1, 1, 0), # Orange approximation 
+            6: (0, 0, 1), # Blue
+            7: (1, 0, 1), # Purple
+            8: (0, 1, 0), # Forest Green approximation
+        }
 
     def send_channel_led(self, channel: int, state: bool) -> None:
         # Send indicator update back to Pico
@@ -179,6 +192,7 @@ class Controller:
             self.bridge.write_sync(msg)
             print(f"[UART->PICO] {msg.decode().strip()}")
 
+
     def send_selected_channel_leds(self) -> None: 
         # Two RGB LEDs used to show the active selected channel: 
         # VP1_RGB and VS1_RGB should always match the selected channel color
@@ -198,6 +212,27 @@ class Controller:
             self.bridge.write_sync(msg)
             print(f"[UART->PICO] {msg.decode().strip()}")
 
+    def get_scope_selected_source(self) -> int:
+        resp = self.scope.query("DISPLAY:SELECT:SOURCE?").strip().upper()
+
+        if resp.endswith("NONE"):
+            return 0
+
+        for ch in range(1, 9):
+            if resp.endswith(f"CH{ch}") or f"CH{ch}" in resp:
+                return ch
+
+        print(f"[SYNC] Unknown selected source response: {resp}")
+        return self._source_channel
+
+
+    def sync_selected_source_from_scope(self) -> None:
+        actual_source = self.get_scope_selected_source()
+
+        if actual_source != self._source_channel:
+            self._source_channel = actual_source
+            self.send_selected_channel_leds()
+            print(f"[SYNC] selected source -> CH{actual_source}")
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):
             return
@@ -222,9 +257,9 @@ class Controller:
             self._source_channel = channel
 
         if self._source_channel == 0:
-            self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
+            self.scope.write("DISPLAY:SELECT:SOURCE NONE")
         else:
-            self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+            self.scope.write(f"DISPLAY:SELECT:SOURCE CH{self._source_channel}")
 
         self.send_selected_channel_leds()
 
@@ -472,7 +507,6 @@ def main() -> None:
     api_thead.start()
     startup_event.wait()
 
-<<<<<<< HEAD
     # ctrl setup
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
     scopes: dict[str, Controller] = {}
@@ -491,8 +525,9 @@ def main() -> None:
         scope.write("HORIZONTAL:DELAY:MODE OFF")
         idn = scope.query("*IDN?").strip()
         print("Connected ctrl:", idn)
+
         ctrl = Controller(scope, bridge)
-        ctrl.sync_channels_from_scope()
+        ctrl.sync_all_channels_from_scope()
         scopes[resource_name] = ctrl
 
     def handle_packet(packet: RawPacket) -> None:
@@ -541,23 +576,15 @@ def main() -> None:
                         # TODO record for slot data.slot
                         # If a different slot is recording, stop that one first.
                     else:
-                        pass  # TODO stop recording for slot data.slot
+                        pass # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
-=======
-    bridge = connect_uart()
-    controller = Controller(scope, bridge)
-    controller.sync_all_channels_from_scope()  # initial sync of all channels
-<<<<<<< HEAD
-    #controller.sync_channels_from_scope()
->>>>>>> 6462816 (removed per-channel rgb color functionality to decrease uart message sending delays. only turns on red channel for each led. also slightly decreased response time of channel synchronization between scope and afp)
-=======
->>>>>>> b4516db (replaced duplicate channel_colors dictionary with one class constant)
 
     try:
         last_sync = time.monotonic()
         last_input = 0.0 # no input yet
         sync_period_s = 0.05
+
         while True:
             raw = bridge.get()
             if scopes and raw:
@@ -577,19 +604,10 @@ def main() -> None:
                 handle_packet(new_packet)
 
             now = time.monotonic()
-<<<<<<< HEAD
-<<<<<<< HEAD
-            if scopes and now - last_sync > sync_period_s and now - last_input > 0.1:
+            if scopes and now - last_sync > sync_period_s and now - last_input > 0.05:
                 ctrl = list(scopes.values())[0]
-                ctrl.sync_channels_from_scope()
-=======
-            if now - last_sync > sync_period_s and now - last_input > 0.05: # 100ms cooldown
-                controller.sync_all_changed_channels_from_scope() # incremental sync to detect external changes
->>>>>>> 6462816 (removed per-channel rgb color functionality to decrease uart message sending delays. only turns on red channel for each led. also slightly decreased response time of channel synchronization between scope and afp)
-=======
-            if now - last_sync > sync_period_s and now - last_input > 0.05: 
-                controller.sync_all_changed_channels_from_scope() 
->>>>>>> b4516db (replaced duplicate channel_colors dictionary with one class constant)
+                ctrl.sync_all_changed_channels_from_scope()
+                ctrl.sync_selected_source_from_scope()
                 last_sync = now
 
     except KeyboardInterrupt:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import threading
+import time
 
 import pyvisa
 from pyvisa.resources import MessageBasedResource
@@ -81,8 +82,35 @@ class Controller:
 
         self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
         self._source_channel: int = 0
-
         self._vert_fine: bool = False # fine mode toggle for vertical scale
+
+    def get_scope_channel_state(self, channel: int) -> bool:
+        resp = self.scope.query(f"DISPLAY:GLOBAL:CH{channel}:STATE?").strip().upper()
+        return resp.endswith("1") or resp.endswith("ON")
+
+    def sync_channels_from_scope(self) -> None:
+        changed = False
+
+        for ch in range(1, 9):
+            actual = self.get_scope_channel_state(ch)
+            if self._channels[ch] != actual:
+                self._channels[ch] = actual
+                self.send_channel_led(ch, actual)
+                changed = True
+                print(f"[SYNC] CH{ch} -> {actual}")
+
+        # Keep selected source sane if current source is now off
+        if self._source_channel != 0 and not self._channels[self._source_channel]:
+            highest = 0
+            for k, v in self._channels.items():
+                if v:
+                    highest = k
+            self._source_channel = highest
+
+            if changed and self._source_channel == 0:
+                self.scope.write(f"DISPLAY:SELECT:SOURCE:NONE")
+            elif changed:
+                self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
 
     def send_channel_led(self, channel: int, state: bool) -> None:
         # Send indicator update back to Pico
@@ -369,7 +397,6 @@ def main() -> None:
     api_thead.start()
     startup_event.wait()
 
-<<<<<<< HEAD
     # ctrl setup
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
     scopes: dict[str, Controller] = {}
@@ -439,11 +466,8 @@ def main() -> None:
                         pass  # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
-=======
-    bridge = connect_uart()
-    controller = Controller(scope, bridge)
-    controller.sync_all_channel_leds()
->>>>>>> 79e1ac7 (added startup LED sync between scope and pico)
+    last_sync = time.monotonic()
+    sync_period_s = 0.25
 
     try:
         while True:
@@ -459,6 +483,11 @@ def main() -> None:
             new_packet = get_raw_packet()
             if new_packet:
                 handle_packet(new_packet)
+
+            now = time.monotonic()
+            if scopes and now - last_sync > sync_period_s:
+                list(scopes.values())[0].sync_channels_from_scope()
+                last_sync = now
 
     except KeyboardInterrupt:
         print("\nExiting...")

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -93,6 +93,10 @@ class Controller:
         self.bridge.queue_write(msg)
         print(f"[UART]->PICO] {msg.decode().strip()}")
 
+    def sync_all_channel_leds(self) -> None:
+        for ch in range(1,9):
+            self.send_channel_led(ch, self._channels[ch])
+
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):
             return
@@ -365,6 +369,7 @@ def main() -> None:
     api_thead.start()
     startup_event.wait()
 
+<<<<<<< HEAD
     # ctrl setup
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
     scopes: dict[str, Controller] = {}
@@ -434,6 +439,11 @@ def main() -> None:
                         pass  # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
+=======
+    bridge = connect_uart()
+    controller = Controller(scope, bridge)
+    controller.sync_all_channel_leds()
+>>>>>>> 79e1ac7 (added startup LED sync between scope and pico)
 
     try:
         while True:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -189,7 +189,8 @@ class Controller:
         ]
 
         msg = f"IV{channel}0_R:{1 if state else 0}\n".encode("utf-8")
-        self.bridge.queue_write(msg)
+        #self.bridge.queue_write(msg)
+        self.bridge.write_sync(msg)
         print(f"[UART->PICO] {msg.decode().strip()}")
 
         #for msg in msgs:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -83,7 +83,7 @@ class Controller:
         self._source_channel: int = 0
 
         self._vert_fine: bool = False # fine mode toggle for vertical scale
-        
+
     def send_channel_led(self, channel: int, state: bool) -> None:
         # Send indicator update back to Pico
         if channel not in range(1,9):
@@ -383,7 +383,7 @@ def main() -> None:
         scope.write("HORIZONTAL:DELAY:MODE OFF")
         idn = scope.query("*IDN?").strip()
         print("Connected ctrl:", idn)
-        scopes[resource_name] = Controller(scope)
+        scopes[resource_name] = Controller(scope, bridge)
 
     def handle_packet(packet: RawPacket) -> None:
         for pd in packet["data"]:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -122,10 +122,6 @@ class Controller:
         self.bridge.queue_write(msg)
         print(f"[UART->PICO] {msg.decode().strip()}")
 
-    def sync_all_channel_leds(self) -> None:
-        for ch in range(1,9):
-            self.send_channel_led(ch, self._channels[ch])
-
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):
             return

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -95,7 +95,19 @@ class Controller:
             actual = self.get_scope_channel_state(ch)
             self._channels[ch] = actual
             self.send_channel_led(ch, actual)
+<<<<<<< HEAD
             print(f"[SYNC] CH{ch} -> {actual}")
+=======
+            if actual:
+                highest = ch
+            print(f"[INIT] CH{ch} -> {actual}")
+
+        # Chooses highest enabled channel as the acive selected channel
+        self._source_channel = highest
+
+        self.set_scope_selected_source()
+        self.send_selected_channel_leds()
+>>>>>>> bbe7876 (created helper function that selects the source channel from the afp to the scope. this replaces repeated blocks of code that did the same thing with one clean function call)
 
     def sync_all_changed_channels_from_scope(self) -> None:
         any_changed = False
@@ -108,6 +120,14 @@ class Controller:
                 print(f"[SYNC] CH{ch} -> {actual}")
                 any_changed = True
 
+<<<<<<< HEAD
+=======
+                if actual:
+                    self._source_channel = ch
+                    self.scope.write(f"DISPLAY:SELECT:SOURCE CH{self._source_channel}")
+                    self.send_selected_channel_leds()
+
+>>>>>>> bbe7876 (created helper function that selects the source channel from the afp to the scope. this replaces repeated blocks of code that did the same thing with one clean function call)
         # Keep selected source sane if current source is now off
         if self._source_channel != 0 and not self._channels[self._source_channel]:
             highest = 0
@@ -117,10 +137,15 @@ class Controller:
 
             self._source_channel = highest
 
+<<<<<<< HEAD
             if self._source_channel == 0:
                 self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
             else:
                 self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+=======
+            self.set_scope_selected_source()
+            self.send_selected_channel_leds()
+>>>>>>> bbe7876 (created helper function that selects the source channel from the afp to the scope. this replaces repeated blocks of code that did the same thing with one clean function call)
 
         # If nothing changed, stay quiet
         if any_changed:
@@ -226,6 +251,13 @@ class Controller:
         return self._source_channel
 
 
+    def set_scope_selected_source(self) -> None:
+        if self._source_channel == 0:
+            self.scope.write("DISPLAY:SELECT:SOURCE NONE")
+        else:
+            self.scope.write(f"DISPLAY:SELECT:SOURCE CH{self._source_channel}")
+
+
     def sync_selected_source_from_scope(self) -> None:
         actual_source = self.get_scope_selected_source()
 
@@ -256,11 +288,7 @@ class Controller:
             self._channels[channel] = True
             self._source_channel = channel
 
-        if self._source_channel == 0:
-            self.scope.write("DISPLAY:SELECT:SOURCE NONE")
-        else:
-            self.scope.write(f"DISPLAY:SELECT:SOURCE CH{self._source_channel}")
-
+        self.set_scope_selected_source()
         self.send_selected_channel_leds()
 
         if last_state != self._channels[channel]:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -89,9 +89,9 @@ class Controller:
         if channel not in range(1,9):
             return
 
-        msg = f"V{channel}0:{1 if state else 0}\n"
-        self.bridge.write(msg.encode("utf-8"))
-        print(f"[UART]->PICO] {msg.strip()}")
+        msg = f"V{channel}0:{1 if state else 0}\n".encode("utf-8")
+        self.bridge.queue_write(msg)
+        print(f"[UART]->PICO] {msg.decode().strip()}")
 
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -277,8 +277,7 @@ class Controller:
             for k, v in self._channels.items():
                 if v:
                     highest = k
-                    if k > channel:
-                        break
+                    
             self._source_channel = highest
         elif last_state:
             # enabled => set as source

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -97,6 +97,36 @@ class Controller:
             self.send_channel_led(ch, actual)
             print(f"[SYNC] CH{ch} -> {actual}")
 
+    def sync_all_changed_channels_from_scope(self) -> None:
+        any_changed = False
+
+        for ch in range(1,9):
+            actual = self.get_scope_channel_state(ch)
+            if self._channels[ch] != actual:
+                self._channels[ch] = actual
+                self.send_channel_led(ch, actual)
+                print(f"[SYNC] CH{ch} -> {actual}")
+                any_changed = True
+
+        # Keep selected source sane if current source is now off
+        if self._source_channel != 0 and not self._channels[self._source_channel]:
+            highest = 0
+            for k, v in self._channels.items():
+                if v:
+                    highest = k
+
+            self._source_channel = highest
+
+            if self._source_channel == 0:
+                self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
+            else:
+                self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+        # If nothing changed, stay quiet
+        if any_changed:
+            print("[SYNC] Full channel sync pass complete")
+
+
     def sync_channels_from_scope(self) -> None:
         ch = self._sync_index
 
@@ -153,9 +183,14 @@ class Controller:
             f"IV{channel}0_B:{b}\n".encode("utf-8"),
         ]
 
-        for msg in msgs:
-            self.bridge.queue_write(msg)
-            print(f"[UART->PICO] {msg.decode().strip()}")
+        msg = f"IV{channel}0_R:{1 if state else 0}\n".encode("utf-8")
+        self.bridge.queue_write(msg)
+        print(f"[UART->PICO] {msg.decode().strip()}")
+
+        #for msg in msgs:
+            #self.bridge.queue_write(msg)
+            #print(f"[UART->PICO] {msg.decode().strip()}")
+
         #msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
         #self.bridge.queue_write(msg)
         #print(f"[UART->PICO] {msg.decode().strip()}")
@@ -432,6 +467,7 @@ def main() -> None:
     api_thead.start()
     startup_event.wait()
 
+<<<<<<< HEAD
     # ctrl setup
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
     scopes: dict[str, Controller] = {}
@@ -503,6 +539,13 @@ def main() -> None:
                         pass  # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
+=======
+    bridge = connect_uart()
+    controller = Controller(scope, bridge)
+    #controller.sync_all_channels_from_scope() # initial sync of all
+    controller.sync_all_channels_from_scope()  # initial sync of all channels
+    #controller.sync_channels_from_scope()
+>>>>>>> 6462816 (removed per-channel rgb color functionality to decrease uart message sending delays. only turns on red channel for each led. also slightly decreased response time of channel synchronization between scope and afp)
 
     try:
         last_sync = time.monotonic()
@@ -527,9 +570,14 @@ def main() -> None:
                 handle_packet(new_packet)
 
             now = time.monotonic()
+<<<<<<< HEAD
             if scopes and now - last_sync > sync_period_s and now - last_input > 0.1:
                 ctrl = list(scopes.values())[0]
                 ctrl.sync_channels_from_scope()
+=======
+            if now - last_sync > sync_period_s and now - last_input > 0.05: # 100ms cooldown
+                controller.sync_all_changed_channels_from_scope() # incremental sync to detect external changes
+>>>>>>> 6462816 (removed per-channel rgb color functionality to decrease uart message sending delays. only turns on red channel for each led. also slightly decreased response time of channel synchronization between scope and afp)
                 last_sync = now
 
     except KeyboardInterrupt:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -130,9 +130,35 @@ class Controller:
         if channel not in range(1,9):
             return
 
-        msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
-        self.bridge.queue_write(msg)
-        print(f"[UART->PICO] {msg.decode().strip()}")
+        # Per-channel RGB color (R,G,B)
+        channel_colors: dict[int, tuple[int, int, int]] = {
+            1: (1, 1, 0), # Yellow
+            2: (0, 1, 1), # Cyan
+            3: (1, 0, 0), # Red
+            4: (0, 1, 0), # Lime Green
+            5: (1, 1, 0), # Orange approximation 
+            6: (0, 0, 1), # Blue
+            7: (1, 0, 1), # Purple
+            8: (0, 1, 0), # Forest Green approximation
+        }
+
+        r, g, b = channel_colors[channel]
+
+        if not state: 
+            r, g, b = 0, 0, 0
+
+        msgs = [
+            f"IV{channel}0_R:{r}\n".encode("utf-8"), 
+            f"IV{channel}0_G:{g}\n".encode("utf-8"),
+            f"IV{channel}0_B:{b}\n".encode("utf-8"),
+        ]
+
+        for msg in msgs:
+            self.bridge.queue_write(msg)
+            print(f"[UART->PICO] {msg.decode().strip()}")
+        #msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
+        #self.bridge.queue_write(msg)
+        #print(f"[UART->PICO] {msg.decode().strip()}")
 
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -117,7 +117,7 @@ class Controller:
         if channel not in range(1,9):
             return
 
-        msg = f"V{channel}0:{1 if state else 0}\n".encode("utf-8")
+        msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
         self.bridge.queue_write(msg)
         print(f"[UART]->PICO] {msg.decode().strip()}")
 
@@ -466,6 +466,7 @@ def main() -> None:
                         pass  # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
+
     last_sync = time.monotonic()
     sync_period_s = 0.25
 

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -75,13 +75,23 @@ def connect_uart(mock: bool = False) -> UARTBridge:
 
 
 class Controller:
-    def __init__(self, scope: MessageBasedResource) -> None:
+    def __init__(self, scope: MessageBasedResource, bridge: UARTBridge) -> None:
         self.scope: MessageBasedResource = scope
+        self.bridge: UARTBridge = bridge 
 
         self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
         self._source_channel: int = 0
 
         self._vert_fine: bool = False # fine mode toggle for vertical scale
+        
+    def send_channel_led(self, channel: int, state: bool) -> None:
+        # Send indicator update back to Pico
+        if channel not in range(1,9):
+            return
+
+        msg = f"V{channel}0:{1 if state else 0}\n"
+        self.bridge.write(msg.encode("utf-8"))
+        print(f"[UART]->PICO] {msg.strip()}")
 
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -188,14 +188,14 @@ class Controller:
             f"IV{channel}0_B:{b}\n".encode("utf-8"),
         ]
 
-        msg = f"IV{channel}0_R:{1 if state else 0}\n".encode("utf-8")
+        #msg = f"IV{channel}0_R:{1 if state else 0}\n".encode("utf-8")
         #self.bridge.queue_write(msg)
-        self.bridge.write_sync(msg)
-        print(f"[UART->PICO] {msg.decode().strip()}")
+        #self.bridge.write_sync(msg)
+        #print(f"[UART->PICO] {msg.decode().strip()}")
 
-        #for msg in msgs:
-            #self.bridge.queue_write(msg)
-            #print(f"[UART->PICO] {msg.decode().strip()}")
+        for msg in msgs:
+            self.bridge.write_sync(msg)
+            print(f"[UART->PICO] {msg.decode().strip()}")
 
         #msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
         #self.bridge.queue_write(msg)

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -80,8 +80,6 @@ class Controller:
         self.scope: MessageBasedResource = scope
         self.bridge: UARTBridge = bridge 
 
-        self._sync_index: int = 1
-
         self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
         self._source_channel: int = 0
         self._vert_fine: bool = False # fine mode toggle for vertical scale
@@ -91,23 +89,20 @@ class Controller:
         return resp.endswith("1") or resp.endswith("ON")
 
     def sync_all_channels_from_scope(self) -> None:
+        highest = 0
         for ch in range(1, 9):
             actual = self.get_scope_channel_state(ch)
             self._channels[ch] = actual
             self.send_channel_led(ch, actual)
-<<<<<<< HEAD
-            print(f"[SYNC] CH{ch} -> {actual}")
-=======
             if actual:
                 highest = ch
             print(f"[INIT] CH{ch} -> {actual}")
 
-        # Chooses highest enabled channel as the acive selected channel
+        # Chooses highest enabled channel as the active selected channel
         self._source_channel = highest
 
         self.set_scope_selected_source()
         self.send_selected_channel_leds()
->>>>>>> bbe7876 (created helper function that selects the source channel from the afp to the scope. this replaces repeated blocks of code that did the same thing with one clean function call)
 
     def sync_all_changed_channels_from_scope(self) -> None:
         any_changed = False
@@ -120,14 +115,11 @@ class Controller:
                 print(f"[SYNC] CH{ch} -> {actual}")
                 any_changed = True
 
-<<<<<<< HEAD
-=======
                 if actual:
                     self._source_channel = ch
                     self.scope.write(f"DISPLAY:SELECT:SOURCE CH{self._source_channel}")
                     self.send_selected_channel_leds()
 
->>>>>>> bbe7876 (created helper function that selects the source channel from the afp to the scope. this replaces repeated blocks of code that did the same thing with one clean function call)
         # Keep selected source sane if current source is now off
         if self._source_channel != 0 and not self._channels[self._source_channel]:
             highest = 0
@@ -137,65 +129,24 @@ class Controller:
 
             self._source_channel = highest
 
-<<<<<<< HEAD
-            if self._source_channel == 0:
-                self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
-            else:
-                self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
-=======
             self.set_scope_selected_source()
             self.send_selected_channel_leds()
->>>>>>> bbe7876 (created helper function that selects the source channel from the afp to the scope. this replaces repeated blocks of code that did the same thing with one clean function call)
 
         # If nothing changed, stay quiet
         if any_changed:
             print("[SYNC] Full channel sync pass complete")
 
-
-    def sync_channels_from_scope(self) -> None:
-        ch = self._sync_index
-
-        actual = self.get_scope_channel_state(ch)
-        if self._channels[ch] != actual:
-            self._channels[ch] = actual
-            self.send_channel_led(ch, actual)
-            print(f"[SYNC] CH{ch} -> {actual}")
-
-            # Keep selected source sane if current source is now off
-            if self._source_channel != 0 and not self._channels[self._source_channel]:
-                highest = 0
-                for k, v in self._channels.items():
-                    if v:
-                        highest = k
-                self._source_channel = highest
-
-                # Always write, not just when changed, to ensure source updates if it was changed externally
-                if self._source_channel == 0:
-                    self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
-                else:
-                    self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
-
-        self._sync_index += 1
-        if self._sync_index > 8:
-            self._sync_index = 1
-
-
-    def send_channel_led(self, channel: int, state: bool) -> None:
-        # Send indicator update back to Pico
-        if channel not in range(1,9):
-            return
-
-        # Per-channel RGB color (R,G,B)
-        channel_colors: dict[int, tuple[int, int, int]] = {
-            1: (1, 1, 0), # Yellow
-            2: (0, 1, 1), # Cyan
-            3: (1, 0, 0), # Red
-            4: (0, 1, 0), # Lime Green
-            5: (1, 1, 0), # Orange approximation 
-            6: (0, 0, 1), # Blue
-            7: (1, 0, 1), # Purple
-            8: (0, 1, 0), # Forest Green approximation
-        }
+    # Per-channel RGB color (R,G,B)
+    CHANNEL_COLORS: dict[int, tuple[int, int, int]] = {
+        1: (1, 1, 0),  # Yellow
+        2: (0, 1, 1),  # Cyan
+        3: (1, 0, 0),  # Red
+        4: (0, 1, 0),  # Lime Green
+        5: (1, 1, 0),  # Orange approximation
+        6: (0, 0, 1),  # Blue
+        7: (1, 0, 1),  # Purple
+        8: (0, 1, 0),  # Forest Green approximation
+    }
 
     def send_channel_led(self, channel: int, state: bool) -> None:
         # Send indicator update back to Pico
@@ -265,6 +216,7 @@ class Controller:
             self._source_channel = actual_source
             self.send_selected_channel_leds()
             print(f"[SYNC] selected source -> CH{actual_source}")
+
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):
             return
@@ -277,7 +229,6 @@ class Controller:
             for k, v in self._channels.items():
                 if v:
                     highest = k
-                    
             self._source_channel = highest
         elif last_state:
             # enabled => set as source
@@ -535,7 +486,7 @@ def main() -> None:
     startup_event.wait()
 
     # ctrl setup
-    rm: pyvisa.ResourceManager = pyvisa.ResourceManager()
+    rm: pyvisa.ResourceManager = pyvisa.ResourceManager(PYVISA_BACKEND)
     scopes: dict[str, Controller] = {}
 
     def connect_to_scope(resource_name: str) -> None:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -80,8 +80,6 @@ class Controller:
         self.scope: MessageBasedResource = scope
         self.bridge: UARTBridge = bridge 
 
-        self._sync_index: int = 1
-
         self._channels: dict[int, bool] = {ch: False for ch in range(1, 9)}
         self._source_channel: int = 0
         self._vert_fine: bool = False # fine mode toggle for vertical scale
@@ -91,6 +89,8 @@ class Controller:
         return resp.endswith("1") or resp.endswith("ON")
 
     def sync_all_channels_from_scope(self) -> None:
+        highest = 0
+
         for ch in range(1, 9):
             actual = self.get_scope_channel_state(ch)
             self._channels[ch] = actual
@@ -99,13 +99,7 @@ class Controller:
                 highest = ch
             print(f"[INIT] CH{ch} -> {actual}")
 
-            # Only tell Pico about channels that should be ON
-            # Due to Pico LEDs starting OFF when powered ON
-            #if actual:
-                #self.send_channel_led(ch, True)
-                #highest = ch
-
-        # Chooses highest enabled channel ast the acive selected channel
+        # Chooses highest enabled channel as the acive selected channel
         self._source_channel = highest
 
         if self._source_channel == 0:
@@ -125,6 +119,11 @@ class Controller:
                 self.send_channel_led(ch, actual)
                 print(f"[SYNC] CH{ch} -> {actual}")
                 any_changed = True
+
+                if actual:
+                    self._source_channel = ch
+                    self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+                    self.send_selected_channel_leds()
 
         # Keep selected source sane if current source is now off
         if self._source_channel != 0 and not self._channels[self._source_channel]:
@@ -147,34 +146,17 @@ class Controller:
             print("[SYNC] Full channel sync pass complete")
 
 
-    def sync_channels_from_scope(self) -> None:
-        ch = self._sync_index
-
-        actual = self.get_scope_channel_state(ch)
-        if self._channels[ch] != actual:
-            self._channels[ch] = actual
-            self.send_channel_led(ch, actual)
-            print(f"[SYNC] CH{ch} -> {actual}")
-
-            # Keep selected source sane if current source is now off
-            if self._source_channel != 0 and not self._channels[self._source_channel]:
-                highest = 0
-                for k, v in self._channels.items():
-                    if v:
-                        highest = k
-                self._source_channel = highest
-
-                # Always write, not just when changed, to ensure source updates if it was changed externally
-                if self._source_channel == 0:
-                    self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
-                else:
-                    self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
-
-                self.send_selected_channel_leds()
-
-        self._sync_index += 1
-        if self._sync_index > 8:
-            self._sync_index = 1
+    # Per-channel RGB color (R,G,B)
+    CHANNEL_COLORS: dict[int, tuple[int, int, int]] = {
+        1: (1, 1, 0), # Yellow
+        2: (0, 1, 1), # Cyan
+        3: (1, 0, 0), # Red
+        4: (0, 1, 0), # Lime Green
+        5: (1, 1, 0), # Orange approximation 
+        6: (0, 0, 1), # Blue
+        7: (1, 0, 1), # Purple
+        8: (0, 1, 0), # Forest Green approximation
+    }
 
 
     def send_channel_led(self, channel: int, state: bool) -> None:
@@ -182,19 +164,7 @@ class Controller:
         if channel not in range(1,9):
             return
 
-        # Per-channel RGB color (R,G,B)
-        channel_colors: dict[int, tuple[int, int, int]] = {
-            1: (1, 1, 0), # Yellow
-            2: (0, 1, 1), # Cyan
-            3: (1, 0, 0), # Red
-            4: (0, 1, 0), # Lime Green
-            5: (1, 1, 0), # Orange approximation 
-            6: (0, 0, 1), # Blue
-            7: (1, 0, 1), # Purple
-            8: (0, 1, 0), # Forest Green approximation
-        }
-
-        r, g, b = channel_colors[channel]
+        r, g, b = self.CHANNEL_COLORS[channel]
 
         if not state: 
             r, g, b = 0, 0, 0
@@ -205,34 +175,15 @@ class Controller:
             f"IV{channel}0_B:{b}\n".encode("utf-8"),
         ]
 
-        #msg = f"IV{channel}0_R:{1 if state else 0}\n".encode("utf-8")
-        #self.bridge.queue_write(msg)
-        #self.bridge.write_sync(msg)
-        #print(f"[UART->PICO] {msg.decode().strip()}")
-
         for msg in msgs:
             self.bridge.write_sync(msg)
             print(f"[UART->PICO] {msg.decode().strip()}")
 
-        #msg = f"IV{channel}0:{1 if state else 0}\n".encode("utf-8")
-        #self.bridge.queue_write(msg)
-        #print(f"[UART->PICO] {msg.decode().strip()}")
-
     def send_selected_channel_leds(self) -> None: 
-        #Two RGB LEDs used to show the active selected channel: 
+        # Two RGB LEDs used to show the active selected channel: 
         # VP1_RGB and VS1_RGB should always match the selected channel color
-        channel_colors: dict[int, tuple[int, int, int]] = {
-            1: (1, 1, 0), # Yellow
-            2: (0, 1, 1), # Cyan
-            3: (1, 0, 0), # Red
-            4: (0, 1, 0), # Lime Green
-            5: (1, 1, 0), # Orange approximation 
-            6: (0, 0, 1), # Blue
-            7: (1, 0, 1), # Purple
-            8: (0, 1, 0), # Forest Green approximation
-        }
-
-        r, g, b = channel_colors.get(self._source_channel, (0,0,0))
+        
+        r, g, b = self.CHANNEL_COLORS.get(self._source_channel, (0,0,0))
 
         msgs = [
             f"IVP1_R:{r}\n".encode("utf-8"),
@@ -596,10 +547,12 @@ def main() -> None:
 =======
     bridge = connect_uart()
     controller = Controller(scope, bridge)
-    #controller.sync_all_channels_from_scope() # initial sync of all
     controller.sync_all_channels_from_scope()  # initial sync of all channels
+<<<<<<< HEAD
     #controller.sync_channels_from_scope()
 >>>>>>> 6462816 (removed per-channel rgb color functionality to decrease uart message sending delays. only turns on red channel for each led. also slightly decreased response time of channel synchronization between scope and afp)
+=======
+>>>>>>> b4516db (replaced duplicate channel_colors dictionary with one class constant)
 
     try:
         last_sync = time.monotonic()
@@ -625,6 +578,7 @@ def main() -> None:
 
             now = time.monotonic()
 <<<<<<< HEAD
+<<<<<<< HEAD
             if scopes and now - last_sync > sync_period_s and now - last_input > 0.1:
                 ctrl = list(scopes.values())[0]
                 ctrl.sync_channels_from_scope()
@@ -632,6 +586,10 @@ def main() -> None:
             if now - last_sync > sync_period_s and now - last_input > 0.05: # 100ms cooldown
                 controller.sync_all_changed_channels_from_scope() # incremental sync to detect external changes
 >>>>>>> 6462816 (removed per-channel rgb color functionality to decrease uart message sending delays. only turns on red channel for each led. also slightly decreased response time of channel synchronization between scope and afp)
+=======
+            if now - last_sync > sync_period_s and now - last_input > 0.05: 
+                controller.sync_all_changed_channels_from_scope() 
+>>>>>>> b4516db (replaced duplicate channel_colors dictionary with one class constant)
                 last_sync = now
 
     except KeyboardInterrupt:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -125,6 +125,7 @@ class Controller:
             self.scope.write(
                 f"DISPLAY:GLOBAL:CH{channel}:STATE {int(self._channels[channel])}"
             )
+            self.send_channel_led(channel, self._channels[channel]) 
 
         print(
             f"[SCOPE] CH{channel} display -> {self._channels[channel]} (source={self._source_channel})"  # noqa: E501

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -466,10 +466,9 @@ def main() -> None:
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
 
-    last_sync = time.monotonic()
-    sync_period_s = 0.25
-
     try:
+        last_sync = time.monotonic()
+        sync_period_s = 0.05
         while True:
             raw = bridge.get()
             if scopes and raw:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -94,8 +94,13 @@ class Controller:
         for ch in range(1, 9):
             actual = self.get_scope_channel_state(ch)
             self._channels[ch] = actual
-            self.send_channel_led(ch, actual)
-            print(f"[SYNC] CH{ch} -> {actual}")
+            #self.send_channel_led(ch, actual)
+            print(f"[INIT] CH{ch} -> {actual}")
+
+            # Only tell Pico about channels that should be ON
+            # Due to Pico LEDs starting OFF when powered ON
+            if actual:
+                self.send_channel_led(ch, True)
 
     def sync_all_changed_channels_from_scope(self) -> None:
         any_changed = False

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -94,13 +94,26 @@ class Controller:
         for ch in range(1, 9):
             actual = self.get_scope_channel_state(ch)
             self._channels[ch] = actual
-            #self.send_channel_led(ch, actual)
+            self.send_channel_led(ch, actual)
+            if actual:
+                highest = ch
             print(f"[INIT] CH{ch} -> {actual}")
 
             # Only tell Pico about channels that should be ON
             # Due to Pico LEDs starting OFF when powered ON
-            if actual:
-                self.send_channel_led(ch, True)
+            #if actual:
+                #self.send_channel_led(ch, True)
+                #highest = ch
+
+        # Chooses highest enabled channel ast the acive selected channel
+        self._source_channel = highest
+
+        if self._source_channel == 0:
+            self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
+        else:
+            self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+        self.send_selected_channel_leds()
 
     def sync_all_changed_channels_from_scope(self) -> None:
         any_changed = False
@@ -126,6 +139,8 @@ class Controller:
                 self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
             else:
                 self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+            self.send_selected_channel_leds()
 
         # If nothing changed, stay quiet
         if any_changed:
@@ -154,6 +169,8 @@ class Controller:
                     self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
                 else:
                     self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+                self.send_selected_channel_leds()
 
         self._sync_index += 1
         if self._sync_index > 8:
@@ -201,6 +218,35 @@ class Controller:
         #self.bridge.queue_write(msg)
         #print(f"[UART->PICO] {msg.decode().strip()}")
 
+    def send_selected_channel_leds(self) -> None: 
+        #Two RGB LEDs used to show the active selected channel: 
+        # VP1_RGB and VS1_RGB should always match the selected channel color
+        channel_colors: dict[int, tuple[int, int, int]] = {
+            1: (1, 1, 0), # Yellow
+            2: (0, 1, 1), # Cyan
+            3: (1, 0, 0), # Red
+            4: (0, 1, 0), # Lime Green
+            5: (1, 1, 0), # Orange approximation 
+            6: (0, 0, 1), # Blue
+            7: (1, 0, 1), # Purple
+            8: (0, 1, 0), # Forest Green approximation
+        }
+
+        r, g, b = channel_colors.get(self._source_channel, (0,0,0))
+
+        msgs = [
+            f"IVP1_R:{r}\n".encode("utf-8"),
+            f"IVP1_G:{g}\n".encode("utf-8"),
+            f"IVP1_B:{b}\n".encode("utf-8"),
+            f"IVS1_R:{r}\n".encode("utf-8"),
+            f"IVS1_G:{g}\n".encode("utf-8"),
+            f"IVS1_B:{b}\n".encode("utf-8"),
+        ]
+
+        for msg in msgs:
+            self.bridge.write_sync(msg)
+            print(f"[UART->PICO] {msg.decode().strip()}")
+
     def set_channel_display(self, channel: int) -> None:
         if channel not in range(1, 9):
             return
@@ -228,6 +274,8 @@ class Controller:
             self.scope.write("DISPLAY:SELECT:SOURCE:NONE")
         else:
             self.scope.write(f"DISPLAY:SELECT:SOURCE:CH{self._source_channel}")
+
+        self.send_selected_channel_leds()
 
         if last_state != self._channels[channel]:
             self.scope.write(


### PR DESCRIPTION
Synchronizes channel states between oscilloscope and afp. Also synchronizes the source (currently active/selected) channel between both. Follows the set highest enabled channel as the source by default rule. 