### PR TITLE
feat: server packet actions

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -230,6 +230,8 @@ class Controller:
             for k, v in self._channels.items():
                 if v:
                     highest = k
+                    if k > channel:
+                        break
             self._source_channel = highest
         elif last_state:
             # enabled => set as source
@@ -478,6 +480,12 @@ class Controller:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mock", action="store_true", help="Run in mock mode")
+    parser.add_argument(
+        "-a",
+        "--auto",
+        action="store_true",
+        help="Automatically connect to first available scope",
+    )
     args = parser.parse_args()
     # internal setup
     bridge = connect_uart(args.mock)
@@ -508,6 +516,11 @@ def main() -> None:
         ctrl = Controller(scope, bridge)
         ctrl.sync_all_channels_from_scope()
         scopes[resource_name] = ctrl
+        send_packet_data(
+            ScopeInfoPacketData(
+                resource_name, idn, 8
+            )
+        )
 
     def handle_packet(packet: RawPacket) -> None:
         for pd in packet["data"]:
@@ -571,9 +584,12 @@ def main() -> None:
                         # TODO record for slot data.slot
                         # If a different slot is recording, stop that one first.
                     else:
-                        pass # TODO stop recording for slot data.slot
+                        pass  # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
+
+    if args.auto:
+        connect_to_scope(rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")[0])
 
     try:
         last_sync = time.monotonic()

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -230,8 +230,6 @@ class Controller:
             for k, v in self._channels.items():
                 if v:
                     highest = k
-                    if k > channel:
-                        break
             self._source_channel = highest
         elif last_state:
             # enabled => set as source
@@ -480,12 +478,6 @@ class Controller:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mock", action="store_true", help="Run in mock mode")
-    parser.add_argument(
-        "-a",
-        "--auto",
-        action="store_true",
-        help="Automatically connect to first available scope",
-    )
     args = parser.parse_args()
     # internal setup
     bridge = connect_uart(args.mock)
@@ -516,11 +508,6 @@ def main() -> None:
         ctrl = Controller(scope, bridge)
         ctrl.sync_all_channels_from_scope()
         scopes[resource_name] = ctrl
-        send_packet_data(
-            ScopeInfoPacketData(
-                resource_name, idn, 8
-            )
-        )
 
     def handle_packet(packet: RawPacket) -> None:
         for pd in packet["data"]:
@@ -584,12 +571,9 @@ def main() -> None:
                         # TODO record for slot data.slot
                         # If a different slot is recording, stop that one first.
                     else:
-                        pass  # TODO stop recording for slot data.slot
+                        pass # TODO stop recording for slot data.slot
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
-
-    if args.auto:
-        connect_to_scope(rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")[0])
 
     try:
         last_sync = time.monotonic()

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -16,6 +16,7 @@ from tekafp.api_server.packets import (
     MacroRecordPacketData,
     PacketData,
     ScopeActionPacketData,
+    ScopeInfoPacketData,
     ScopeListPacketData,
 )
 from tekafp.input import Input
@@ -416,7 +417,7 @@ class Controller:
             if detents: 
                 self.adjust_vertical_scale(-detents)
             return
-        
+
         # Encoder HS1 rotation: horizontal timebase scale (1/2/4 steps)
         if msg_id == "HS1":
             detents = int(val)
@@ -430,7 +431,7 @@ class Controller:
                 self._vert_fine = not self._vert_fine
                 print(f"[SCOPE] Vertical scale fine mode -> {'ON' if self._vert_fine else 'OFF'}")
             return
-        
+
         # trigger level encoder
         if msg_id == "TL1":
             detents = int(val)
@@ -516,34 +517,50 @@ def main() -> None:
                     print(f"Received packet action='{a}'")
                     match a:
                         case "enable":
-                            print(f"enabling scope {data.scope}")
-                            if not args.mock and data.scope not in scopes:
-                                connect_to_scope(data.scope)
+                            if data.resource_name not in scopes:
+                                print(f"enabling scope {data.resource_name}")
+                                if args.mock:
+                                    scopes[data.resource_name] = None
+                                    send_packet_data(
+                                        ScopeInfoPacketData(
+                                            data.resource_name,
+                                            "TEKTRONIX,MSO58,C012345,CF:91.1CT FV:1.0.1.8",
+                                            8,
+                                        )
+                                    )
+                                else:
+                                    connect_to_scope(data.resource_name)
                         case "disable":
-                            print(f"disabling scope {data.scope}")
-                            if args.mock:
-                                break
-                            if data.scope in scopes:
-                                c = scopes.pop(data.scope)
-                                c.scope.close()
+                            if data.resource_name in scopes:
+                                print(f"disabling scope {data.resource_name}")
+                                if args.mock:
+                                    del scopes[data.resource_name]
+                                else:
+                                    c = scopes.pop(data.resource_name)
+                                    c.scope.close()
                             else:
-                                print(f"scope {data.scope} not enabled: ignoring")
+                                print(
+                                    f"scope {data.resource_name} not enabled: ignoring"
+                                )
                         case "list":
                             if args.mock:
                                 send_packet_data(
                                     ScopeListPacketData(
-                                        [
-                                            "USB0::0x0699::0x0363::C102912::INSTR",
-                                            "USB0::0x0699::0x0408::B011823::INSTR",
-                                        ]
+                                        {
+                                            "USB0::0x0699::0x0363::C102912::INSTR": False,
+                                            "USB0::0x0699::0x0408::B011823::INSTR": True,
+                                        }
                                     )
                                 )
                             else:
                                 send_packet_data(
                                     ScopeListPacketData(
-                                        rm.list_resources(
-                                            "(USB?*::INSTR|TCPIP?*::INSTR)"
-                                        )
+                                        {
+                                            r: r in scopes
+                                            for r in rm.list_resources(
+                                                "(USB?*::INSTR|TCPIP?*::INSTR)"
+                                            )
+                                        }
                                     )
                                 )
                         case _:
@@ -565,7 +582,7 @@ def main() -> None:
 
         while True:
             raw = bridge.get()
-            if scopes and raw:
+            if not args.mock and scopes and raw:
                 try:
                     inp = Input.from_bytes(raw)
                 except Exception as e:

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, fields
 from typing import ClassVar, TypedDict
 
 
@@ -44,22 +44,25 @@ class MacroStatePacketData(PacketData):
 
 @dataclass
 class ScopeActionPacketData(PacketData):
+    resource_name: str
     action: str
-    scope: str
 
 
 @dataclass
 class ScopeInfoPacketData(PacketData):
+    resource_name: str
+    idn: str
     channel_count: int
 
 
 @dataclass
 class ScopeListPacketData(PacketData):
-    scopes: list[str]
+    scopes: dict[str, bool]
 
 
 @dataclass
 class ScopeStatePacketData(PacketData):
+    resource_name: str
     status: str
     channels: list[bool]
     source_channel: int


### PR DESCRIPTION
This adds VISA resource names to all scope packets to associate that data with a particular scope. All relevant packets can now be processed by the server (including macro packets, though they don't actually do anything *yet*). There are some slight changes to what happens with the mock mode on to more closely match real behavior.