### PR TITLE
feat: send log and toast messages from server to client

### DIFF
--- a/afp-ui/Main.cs
+++ b/afp-ui/Main.cs
@@ -72,6 +72,9 @@ public partial class Main : Control
 				    }
 
 				    break;
+			    case LogMessagePacketData lm:
+				    Global.Logger.Log((LogLevel)lm.Level, lm.Message, lm.Toast);
+				    break;
 		    }
 	    }
     }

--- a/afp-ui/Packet/Data/IPacketData.cs
+++ b/afp-ui/Packet/Data/IPacketData.cs
@@ -9,4 +9,5 @@ namespace AFP.Packet.Data;
 [JsonDerivedType(typeof(MacroRecordPacketData), typeDiscriminator: "MacroRecord")]
 [JsonDerivedType(typeof(MacroStatePacketData), typeDiscriminator: "MacroState")]
 [JsonDerivedType(typeof(ScopeActionPacketData), typeDiscriminator: "ScopeAction")]
+[JsonDerivedType(typeof(LogMessagePacketData), typeDiscriminator: "LogMessage")]
 public interface IPacketData {}

--- a/afp-ui/Packet/Data/LogMessagePacketData.cs
+++ b/afp-ui/Packet/Data/LogMessagePacketData.cs
@@ -1,0 +1,8 @@
+namespace AFP.Packet.Data;
+
+public class LogMessagePacketData : IPacketData
+{
+	public required ushort Level { get; set; }
+	public required string Message { get; set; }
+	public required bool Toast { get; set; }
+}

--- a/afp-ui/Packet/Data/LogMessagePacketData.cs.uid
+++ b/afp-ui/Packet/Data/LogMessagePacketData.cs.uid
@@ -1,0 +1,1 @@
+uid://ck20rvnjmhdft

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -1,10 +1,19 @@
 from dataclasses import asdict, dataclass, fields
+from enum import IntEnum
 from typing import ClassVar, TypedDict
+
+
+class LogMessageLevel(IntEnum):
+    INFO = 0
+    WARNING = 1
+    ERROR = 2
+    DEBUG = 3
 
 
 class RawPacket(TypedDict):
     origin: str
     data: list[dict]
+
 
 @dataclass
 class PacketData:
@@ -29,6 +38,13 @@ class PacketData:
 
     def to_dict(self) -> dict:
         return {"type": self.type, **asdict(self)}
+
+
+@dataclass
+class LogMessagePacketData(PacketData):
+    level: LogMessageLevel
+    message: str
+    toast: bool
 
 
 @dataclass


### PR DESCRIPTION
This PR allows sending any log message, optionally as a toast, to the UI from the Python server. For example:

```Python
send_packet_data(
    LogMessagePacketData(LogMessageLevel.INFO, "Hello from the daemon!", True)
)
```
Causes a toast (alert popup) with the specified level of INFO and the string message. It will also be added to the log tab. This can be used to send useful messages about the state of the Python program to the user via the screen. This could easily be overwhelming though (lots of pop-ups), so best to use only where it makes sense.