### PR TITLE
feat: auto connect cli and ui configuration

### DIFF
--- a/afp-ui/Components/ScopeOption.cs
+++ b/afp-ui/Components/ScopeOption.cs
@@ -6,9 +6,12 @@ public partial class ScopeOption : HBoxContainer
 {
 	[Signal]
 	public delegate void ScopeToggledEventHandler(bool enabled, string resourceName);
+
+	public string ResourceName;
 	private BaseButton.ToggledEventHandler _callback;
 	public void Init(string resourceName, bool enabled, ButtonGroup group)
 	{
+		ResourceName = resourceName;
 		GetNode<Label>("Label").Text = resourceName;
 		var c = GetNode<CheckBox>("CheckBox");
 		_callback = on => EmitSignal(SignalName.ScopeToggled, on, resourceName);

--- a/afp-ui/Core/Config.cs
+++ b/afp-ui/Core/Config.cs
@@ -1,8 +1,18 @@
+using System.Collections.Generic;
+
 namespace AFP.Core;
+
+public enum AutoConnectMode : byte
+{
+	None = 0,
+	LastUsed = 1,
+	FirstAvailable = 2,
+}
 
 public class Config
 {
-    public string WebSocketUrl { get; set; } = "ws://127.0.0.1:8000/ws";
-    public bool SaveSelectedScopes { get; set; } = true;
+    public string WebSocketUrl { get; init; } = "ws://127.0.0.1:8000/ws";
+    public AutoConnectMode AutoConnect { get; set; } = AutoConnectMode.None;
+    public List<string> LastUsedScopes { get; init; } = [];
     public bool DebugMode { get; set; }
 }

--- a/afp-ui/Core/Global.cs
+++ b/afp-ui/Core/Global.cs
@@ -6,7 +6,7 @@ namespace AFP.Core;
 
 public partial class Global : Node
 {
-	public static Logger Logger { get; private set; } = new Logger();
+	public static Logger Logger { get; } = new();
     public static Global Instance { get; private set; }
     /// <summary>
     /// Path to the config file
@@ -32,6 +32,11 @@ public partial class Global : Node
         Logger.OnToast += OnToast;
     }
 
+    public override void _ExitTree()
+    {
+	    SaveConfig();
+    }
+
     private void OnToast(LogLevel level, string message)
     {
 	    Toast.Call("add_message_compat", (ushort)level, message);
@@ -43,7 +48,7 @@ public partial class Global : Node
     private void InitConfig()
     {
         Config = new Config();
-        SaveConfig();
+        SaveConfig(true);
     }
     
     /// <summary>
@@ -71,11 +76,11 @@ public partial class Global : Node
     /// <summary>
     /// Write the config to disk
     /// </summary>
-    public void SaveConfig()
+    public void SaveConfig(bool flush = false)
     {
         using FileAccess file = FileAccess.Open(ConfigPath, FileAccess.ModeFlags.Write);
         string json = JsonSerializer.Serialize(Config, JsonSerializerOptions);
         file.StoreString(json);
-        file.Flush();
+        if (flush) file.Flush();
     }
 }

--- a/afp-ui/Core/WebSocketClient.cs
+++ b/afp-ui/Core/WebSocketClient.cs
@@ -10,6 +10,9 @@ namespace AFP.Core;
 
 public partial class WebSocketClient : Node
 {
+	[Signal]
+	public delegate void ConnectedEventHandler();
+	
 	public static WebSocketClient Instance { get; private set; }
 
 	public Queue<PacketContainer> ReceiveQueue { get; private set; }
@@ -124,6 +127,7 @@ public partial class WebSocketClient : Node
 				case WebSocketPeer.State.Open:
 					Global.Logger.Log(LogLevel.Debug, "WebSocket: connected");
 					_connectionAttemptTime = 0;
+					EmitSignal(SignalName.Connected);
 					break;
 				case WebSocketPeer.State.Closing:
 					GD.Print("WebSocket: closing...");

--- a/afp-ui/Main.cs
+++ b/afp-ui/Main.cs
@@ -19,15 +19,18 @@ public partial class Main : Control
 
     public override void _Ready()
     {
-        Global.Instance.Toast = GetNode<Control>("Toast");
-        Global.Instance.LoadConfig();
-        
-        _homeView = GetNode<Home>("ViewManager/Home");
-        _scopesView = GetNode<Scopes>("ViewManager/Scopes");
-        _macroView = GetNode<Macros>("ViewManager/Macros");
-        _scopesView.ScopeToggled += _onScopeToggled;
-        
-        WebSocketClient.Instance.Connect(Global.Instance.Config.WebSocketUrl);
+	    Global.Instance.Toast = GetNode<Control>("Toast");
+	    Global.Instance.LoadConfig();
+
+	    _homeView = GetNode<Home>("ViewManager/Home");
+	    _scopesView = GetNode<Scopes>("ViewManager/Scopes");
+	    _macroView = GetNode<Macros>("ViewManager/Macros");
+	    GetNode<Settings>("ViewManager/Settings").SetFromConfig(Global.Instance.Config);
+	    _scopesView.ScopeToggled += ToggleScope;
+
+	    WebSocketClient.Instance.Connect(WebSocketClient.SignalName.Connected, Callable.From(OnSocketFirstConnect),
+		    (uint)ConnectFlags.OneShot);
+	    WebSocketClient.Instance.Connect(Global.Instance.Config.WebSocketUrl);
     }
 
     public override void _Process(double delta)
@@ -47,16 +50,19 @@ public partial class Main : Control
 			    case ScopeListPacketData sl:
 			    {
 				    Global.Logger.Log(LogLevel.Debug, $"Received ScopeList count={sl.Scopes.Count}");
-				    _scopesView.SetSearchDone();
+				    _scopesView.ClearScopes();
 				    foreach (KeyValuePair<string, bool> entry in sl.Scopes)
 				    {
 					    _scopesView.AddScope(entry.Key, entry.Value);
 				    }
 
+				    _scopesView.SetSearchComplete();
 				    break;
 			    }
 			    case ScopeInfoPacketData si:
 				    _homeView.UpdateScope(si.ResourceName, si.Idn, si.ChannelCount);
+				    Global.Instance.Config.LastUsedScopes[0] = si.ResourceName;
+				    Global.Instance.SaveConfig(true);
 				    ScopeInstance scope = _scopes[si.ResourceName];
 				    scope.Idn = si.Idn;
 				    scope.ChannelCount = si.ChannelCount;
@@ -75,11 +81,50 @@ public partial class Main : Control
 			    case LogMessagePacketData lm:
 				    Global.Logger.Log((LogLevel)lm.Level, lm.Message, lm.Toast);
 				    break;
+			    case ErrorPacketData ep:
+				    if (ep.ErrorCode == 0)
+				    {
+					    _scopes.Remove(ep.ResourceName);
+					    _homeView.RemoveScope(ep.ResourceName);
+				    }
+				    Global.Logger.Log(LogLevel.Error, ep.ErrorStr, true);
+				    break;
 		    }
 	    }
     }
 
-    private void _onScopeToggled(string resourceName, bool state)
+    private void OnSocketFirstConnect()
+    {
+	    switch (Global.Instance.Config.AutoConnect)
+	    {
+		    case AutoConnectMode.LastUsed:
+			    // TODO: update for reconnecting to multiple scopes
+			    if (Global.Instance.Config.LastUsedScopes.Count > 0)
+			    {
+				    string rn = Global.Instance.Config.LastUsedScopes[0];
+				    ToggleScope(rn, true);
+				    Global.Logger.Log(LogLevel.Info, $"Connecting to last scope [{rn}]", true);
+			    }
+			    break;
+		    case AutoConnectMode.FirstAvailable:
+			    _scopesView.Connect(Scopes.SignalName.SearchComplete,
+				    Callable.From(OnFirstScopeSearch), (uint)ConnectFlags.OneShot);
+			    _scopesView.RefreshList();
+			    break;
+		    case AutoConnectMode.None:
+			    break;
+	    }
+    }
+
+    private void OnFirstScopeSearch()
+    {
+	    if (_scopesView.List.GetChildCount() > 0)
+	    {
+		    ToggleScope(_scopesView.List.GetChild<ScopeOption>(0).ResourceName, true);
+	    }
+    }
+
+    private void ToggleScope(string resourceName, bool state)
     {
 	    WebSocketClient.Instance.QueuePacketData(new ScopeActionPacketData
 	    {

--- a/afp-ui/Packet/Data/ErrorPacketData.cs
+++ b/afp-ui/Packet/Data/ErrorPacketData.cs
@@ -1,0 +1,7 @@
+namespace AFP.Packet.Data;
+
+public class ErrorPacketData : ScopePacketData
+{
+	public required int ErrorCode { get; set; }
+	public required string ErrorStr { get; set; }
+}

--- a/afp-ui/Packet/Data/ErrorPacketData.cs.uid
+++ b/afp-ui/Packet/Data/ErrorPacketData.cs.uid
@@ -1,0 +1,1 @@
+uid://boenansy1fm78

--- a/afp-ui/Packet/Data/IPacketData.cs
+++ b/afp-ui/Packet/Data/IPacketData.cs
@@ -10,4 +10,5 @@ namespace AFP.Packet.Data;
 [JsonDerivedType(typeof(MacroStatePacketData), typeDiscriminator: "MacroState")]
 [JsonDerivedType(typeof(ScopeActionPacketData), typeDiscriminator: "ScopeAction")]
 [JsonDerivedType(typeof(LogMessagePacketData), typeDiscriminator: "LogMessage")]
+[JsonDerivedType(typeof(ErrorPacketData), typeDiscriminator: "Error")]
 public interface IPacketData {}

--- a/afp-ui/View/Scopes.cs
+++ b/afp-ui/View/Scopes.cs
@@ -10,19 +10,21 @@ public partial class Scopes : VBoxContainer
 {
 	[Signal]
 	public delegate void ScopeToggledEventHandler(string resourceName, bool enabled);
+	[Signal]
+	public delegate void SearchCompleteEventHandler();
 
 	[Export] private PackedScene _scopeOptionScene;
-	private VBoxContainer _list;
+	public VBoxContainer List;
 	private ButtonGroup _group;
+	private bool _refresh;
 
 	public override void _Ready()
     {
-	    _list = GetNode<VBoxContainer>("%ScopesList");
+	    List = GetNode<VBoxContainer>("%ScopesList");
 	    _group = new ButtonGroup();
 	    _group.AllowUnpress = true;
 	    GetNode<Button>("HBoxContainer/RefreshButton").Pressed += RefreshList;
 	    VisibilityChanged += OnVisibilityChanged;
-
     }
 
 	private void OnVisibilityChanged()
@@ -30,8 +32,14 @@ public partial class Scopes : VBoxContainer
 		if (Visible) RefreshList();
 	}
 
-	private void RefreshList()
+	public void RefreshList()
 	{
+		if (_refresh)
+		{
+			GD.Print("skip refresh");
+			return;
+		}
+		_refresh = true;
 		GetNode<Button>("HBoxContainer/RefreshButton").Text = "Searching...";
 	    WebSocketClient.Instance.SendPacket(new PacketContainer
 	    {
@@ -45,12 +53,13 @@ public partial class Scopes : VBoxContainer
 			    }
 		    ]
 	    });
-	    ClearScopes();
     }
 
-	public void SetSearchDone()
+	public void SetSearchComplete()
 	{
+		_refresh = false;
 		GetNode<Button>("HBoxContainer/RefreshButton").Text = "Refresh";
+		EmitSignal(SignalName.SearchComplete);
 	}
 
     public void AddScope(string resourceName, bool enabled)
@@ -58,12 +67,12 @@ public partial class Scopes : VBoxContainer
 	    var s = _scopeOptionScene.Instantiate<ScopeOption>();
 	    s.Init(resourceName, enabled, _group);
 	    s.ScopeToggled += _onScopeToggled;
-	    _list.AddChild(s);
+	    List.AddChild(s);
     }
 
-    private void ClearScopes()
+    public void ClearScopes()
     {
-	    foreach (Node node in _list.GetChildren())
+	    foreach (Node node in List.GetChildren())
 	    {
 		    var child = (ScopeOption)node;
 		    child.ScopeToggled -= _onScopeToggled;

--- a/afp-ui/View/Settings.cs
+++ b/afp-ui/View/Settings.cs
@@ -9,6 +9,7 @@ public partial class Settings : MarginContainer
 	[Export] private Label _aboutLabel;
 	[Export] private CheckButton _debugToggle;
 	[Export] private Button _setDevWinSize;
+	[Export] private OptionButton _autoConnect;
 
 	// specs from https://4dsystems.com.au/products/gen4-4dpi-70ct-clb/
 	private const float DisplaySize = 7.0f;
@@ -20,6 +21,7 @@ public partial class Settings : MarginContainer
 		_forceCloseButton.Pressed += () => GetTree().Quit(0);
 		_aboutLabel.Text = $"AFP-UI v{ProjectSettings.GetSetting("application/config/version")}";
 		_debugToggle.Toggled += _onDebugToggled;
+		_autoConnect.ItemSelected += OnItemSelected;
 		if (OS.HasFeature("debug"))
 		{
 			_setDevWinSize.Show();
@@ -27,10 +29,22 @@ public partial class Settings : MarginContainer
 		}
 	}
 
+	public void SetFromConfig(Config cfg)
+	{
+		_debugToggle.ButtonPressed = cfg.DebugMode;
+		_autoConnect.Selected = (int)cfg.AutoConnect;
+	}
+
 	private static void _onDebugToggled(bool enabled)
 	{
 		Global.Instance.Config.DebugMode = enabled;
 		Global.Logger.Log(LogLevel.Debug, "debug enabled", true);
+	}
+
+	private static void OnItemSelected(long item)
+	{
+		Global.Instance.Config.AutoConnect = (AutoConnectMode)item;
+		Global.Instance.SaveConfig();
 	}
 
 	private void SetDevWindowSize()

--- a/afp-ui/View/settings.tscn
+++ b/afp-ui/View/settings.tscn
@@ -2,7 +2,11 @@
 
 [ext_resource type="Script" uid="uid://eykx3hs1wrix" path="res://View/Settings.cs" id="1_7lsj5"]
 
-[node name="Settings" type="MarginContainer" unique_id=231371399 node_paths=PackedStringArray("_forceCloseButton", "_aboutLabel", "_debugToggle", "_setDevWinSize")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7lsj5"]
+content_margin_bottom = 16.0
+bg_color = Color(0.105882354, 0.16078432, 0.20784314, 1)
+
+[node name="Settings" type="MarginContainer" unique_id=231371399 node_paths=PackedStringArray("_forceCloseButton", "_aboutLabel", "_debugToggle", "_setDevWinSize", "_autoConnect")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -15,11 +19,13 @@ _forceCloseButton = NodePath("TabContainer/Configuration/Configuration/AdvancedC
 _aboutLabel = NodePath("TabContainer/About")
 _debugToggle = NodePath("TabContainer/Configuration/Configuration/AdvancedContainer/VBoxContainer/DebugMode")
 _setDevWinSize = NodePath("TabContainer/Configuration/Configuration/AdvancedContainer/VBoxContainer/SetDevWindowSize")
+_autoConnect = NodePath("TabContainer/Configuration/Configuration/AutoConnect/OptionButton")
 
 [node name="TabContainer" type="TabContainer" parent="." unique_id=575518546]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+theme_override_styles/tabbar_background = SubResource("StyleBoxFlat_7lsj5")
 tab_alignment = 1
 current_tab = 0
 
@@ -34,6 +40,25 @@ metadata/_tab_index = 0
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+
+[node name="AutoConnect" type="HBoxContainer" parent="TabContainer/Configuration/Configuration" unique_id=448105964]
+layout_mode = 2
+alignment = 1
+
+[node name="Label" type="Label" parent="TabContainer/Configuration/Configuration/AutoConnect" unique_id=1657555133]
+layout_mode = 2
+text = "Auto connect"
+
+[node name="OptionButton" type="OptionButton" parent="TabContainer/Configuration/Configuration/AutoConnect" unique_id=848657673]
+layout_mode = 2
+selected = 0
+item_count = 3
+popup/item_0/text = "None"
+popup/item_0/id = 0
+popup/item_1/text = "Last used instrument"
+popup/item_1/id = 1
+popup/item_2/text = "First available instrument"
+popup/item_2/id = 2
 
 [node name="AdvancedContainer" type="FoldableContainer" parent="TabContainer/Configuration/Configuration" unique_id=847051202]
 layout_mode = 2

--- a/afp-ui/theme/main_theme.tres
+++ b/afp-ui/theme/main_theme.tres
@@ -146,6 +146,7 @@ FoldableContainer/styles/title_collapsed_panel = SubResource("StyleBoxFlat_yhfeq
 FoldableContainer/styles/title_hover_panel = SubResource("StyleBoxFlat_1i34x")
 FoldableContainer/styles/title_panel = SubResource("StyleBoxFlat_1i34x")
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_0omi4")
+PopupMenu/styles/panel = SubResource("StyleBoxFlat_sxwih")
 TabContainer/constants/tab_separation = 4
 TabContainer/fonts/font = ExtResource("1_a2l2q")
 TabContainer/styles/panel = SubResource("StyleBoxFlat_58jnp")

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -1,8 +1,10 @@
 import argparse
 import threading
 import time
+from time import sleep
 
 import pyvisa
+from pyvisa import VisaIOError
 from pyvisa.resources import MessageBasedResource
 
 from tekafp.api_server import (
@@ -12,7 +14,9 @@ from tekafp.api_server import (
     send_packet_data,
     startup_event,
 )
+from tekafp.api_server.error import APIError
 from tekafp.api_server.packets import (
+    ErrorPacketData,
     MacroRecordPacketData,
     PacketData,
     ScopeActionPacketData,
@@ -478,6 +482,12 @@ class Controller:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mock", action="store_true", help="Run in mock mode")
+    parser.add_argument(
+        "-a",
+        "--auto",
+        action="store_true",
+        help="Automatically connect to the first available scope",
+    )
     args = parser.parse_args()
     # internal setup
     bridge = connect_uart(args.mock)
@@ -491,13 +501,21 @@ def main() -> None:
     scopes: dict[str, Controller] = {}
 
     def connect_to_scope(resource_name: str) -> None:
-        scope: MessageBasedResource = rm.open_resource(
-            resource_name,
-            resource_pyclass=MessageBasedResource,
-            timeout=SCOPE_TIMEOUT_MS,
-            write_termination="\n",
-            read_termination="\n",
-        )
+        try:
+            scope: MessageBasedResource = rm.open_resource(
+                resource_name,
+                resource_pyclass=MessageBasedResource,
+                timeout=SCOPE_TIMEOUT_MS,
+                write_termination="\n",
+                read_termination="\n",
+            )
+        except (VisaIOError, ValueError) as err:
+            send_packet_data(
+                ErrorPacketData(
+                    resource_name, APIError.CONNECTION_ERROR, error_str=str(err)
+                )
+            )
+            return
         # Make sure we're in a mode where horizontal position behaves like the
         # front panel knob
         # delay mode OFF => HORizontal:POSition works like HORIZONTAL POSITION knob
@@ -510,17 +528,12 @@ def main() -> None:
         scopes[resource_name] = ctrl
 
     def auto_connect_first_scope() -> None:
-        if args.mock:
-            return
-        
-        resources = list(
-            rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")
-        )
+        resources = rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")
 
         if not resources:
             print("[AUTO] No scopes found")
             return
-        
+
         first = resources[0]
         print(f"[AUTO] Connecting to: {first}")
 
@@ -566,15 +579,11 @@ def main() -> None:
                                     ScopeListPacketData(
                                         {
                                             "USB0::0x0699::0x0363::C102912::INSTR": False,
-                                            "USB0::0x0699::0x0408::B011823::INSTR": True,
+                                            "USB0::0x0699::0x0408::B011823::INSTR": False,
                                         }
                                     )
                                 )
                             else:
-                                resources = list(
-                                    rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")
-                                )
-
                                 send_packet_data(
                                     ScopeListPacketData(
                                         {
@@ -597,7 +606,8 @@ def main() -> None:
                 case _:
                     print(f"Unknown or incorrect packet type {data.type}")
 
-    auto_connect_first_scope()
+    if args.auto:
+        auto_connect_first_scope()
 
     try:
         last_sync = time.monotonic()
@@ -623,7 +633,7 @@ def main() -> None:
                 handle_packet(new_packet)
 
             now = time.monotonic()
-            if scopes and now - last_sync > sync_period_s and now - last_input > 0.05:
+            if not args.mock and scopes and now - last_sync > sync_period_s and now - last_input > 0.05:
                 ctrl = list(scopes.values())[0]
                 ctrl.sync_all_changed_channels_from_scope()
                 ctrl.sync_selected_source_from_scope()
@@ -633,7 +643,8 @@ def main() -> None:
         print("\nExiting...")
     finally:
         for ctrl in scopes.values():
-            ctrl.scope.close()
+            if ctrl:
+                ctrl.scope.close()
         bridge.close()
 
 

--- a/software/tekafp/api_server/error.py
+++ b/software/tekafp/api_server/error.py
@@ -1,0 +1,6 @@
+from enum import IntEnum, unique
+
+
+@unique
+class APIError(IntEnum):
+    CONNECTION_ERROR = 0,

--- a/software/tekafp/api_server/packets.py
+++ b/software/tekafp/api_server/packets.py
@@ -2,6 +2,8 @@ from dataclasses import asdict, dataclass, fields
 from enum import IntEnum
 from typing import ClassVar, TypedDict
 
+from tekafp.api_server.error import APIError
+
 
 class LogMessageLevel(IntEnum):
     INFO = 0
@@ -56,6 +58,13 @@ class MacroRecordPacketData(PacketData):
 @dataclass
 class MacroStatePacketData(PacketData):
     macros: list[bool]
+
+
+@dataclass
+class ErrorPacketData(PacketData):
+    resource_name: str
+    error_code: APIError
+    error_str: str
 
 
 @dataclass


### PR DESCRIPTION
The actual function of the auto connect is the same, this adds several changes and fixes to extend the functionality:

- The UI settings menu adds an Auto Connect option, with "None," "last used," and "first available"
- Python CLI arg (-a, --auto) to automatically connect to first available scope (allows use with or without mock mode)
- Ensure values are loaded from config, and flush to disk routinely (changes would not be cleanly saved on power cut)
- New error packets (ErrorPacketData) are added to communicate connection errors to the user. They can be associated with a VISA resource, and are handled differently than the LogMessage packets (which only display the message, whereas ErrorPackets take action to handle the errors)
- Stop multiple scope list refreshes from occurring at the same time (should be more responsive, and fix duplicate scope entries in the UI)
- VISA error handling when attempting to connect to a nonexistent or malformed scope address
- A handful of small fixes from crashes while testing

Closes #44 