### PR TITLE
fix: singular uart messages are written per 1s loop

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -73,7 +73,7 @@ HORIZ_SCALE_STEPS = [
 def connect_uart(mock: bool = False) -> UARTBridge:
     if mock:
         return MockUARTBridge(PORT, baudrate=BAUD, timeout=1, write_timeout=1)
-    bridge = UARTBridge(PORT, baudrate=BAUD, timeout=1, write_timeout=1)
+    bridge = UARTBridge(PORT, baudrate=BAUD, timeout=0.1, write_timeout=1)
     if not bridge.connect():
         raise RuntimeError(f"Failed to open UART on {PORT}")
     print(f"Connected UART: {PORT} @ {BAUD}")

--- a/software/tekafp/uart/__init__.py
+++ b/software/tekafp/uart/__init__.py
@@ -31,25 +31,24 @@ class UARTBridge:
         self.baudrate: int = baudrate
         self.timeout: Optional[float] = timeout
         self.write_timeout: Optional[float] = write_timeout
-        self.serial: serial.Serial | None = None
+        self.serial: serial.Serial = None
         self._thread = None
         self._close_thread = False
 
     def _thread_main(self) -> None:
         while not self._close_thread:
             # writing
-            try:
-                data = self._write_queue.get_nowait()
-            except Empty:
-                pass
-            except ShutDown:
-                pass
-            else:
+            while True:
                 try:
-                    self.serial.write(data)
-                except serial.SerialTimeoutException:
-                    self._write_queue.put(data)
-                self._write_queue.task_done()
+                    data = self._write_queue.get_nowait()
+                except (Empty, ShutDown):
+                    break
+                else:
+                    try:
+                        self.serial.write(data)
+                    except serial.SerialTimeoutException:
+                        self._write_queue.put(data)
+                    self._write_queue.task_done()
 
             # reading
             data: bytes = self.serial.readline()
@@ -61,6 +60,8 @@ class UARTBridge:
                         break
                 else:
                     print("UART error: incomplete message")
+                    # discard until beginning of next packet
+                    self.serial.read_until(b"\n")
 
     def connect(self) -> bool:
         """
@@ -78,9 +79,7 @@ class UARTBridge:
                     timeout=self.timeout,
                     write_timeout=self.write_timeout
                 )
-        except serial.SerialException:
-            return False
-        except ValueError:
+        except (serial.SerialException, ValueError):
             return False
         self._queue = Queue()
         self._close_thread = False
@@ -118,9 +117,7 @@ class UARTBridge:
                 data = self._queue.get_nowait()
             self._queue.task_done()
             return data
-        except Empty:
-            return None
-        except ShutDown:
+        except (Empty, ShutDown):
             return None
 
     def queue_write(self, data: bytes) -> None:
@@ -132,7 +129,7 @@ class UARTBridge:
         try:
             self._write_queue.put(data)
         except ShutDown:
-            pass
+            return
 
     def write_sync(self, data: bytes) -> bool:
         """

--- a/software/test/uart/test_uart.py
+++ b/software/test/uart/test_uart.py
@@ -1,22 +1,59 @@
+from collections.abc import Generator
+import time
+
+import pytest
 import serial
 
 from tekafp.uart import UARTBridge
 
 
-def test_uart_read() -> None:
-    msg: bytes = b'testing123\n'
-
-    bridge = UARTBridge("/dev/serial0", timeout=1, write_timeout=1)
-    # overwrite the default serial with a loopback url
+@pytest.fixture
+def uart_bridge() -> Generator[UARTBridge, None, None]:
+    bridge = UARTBridge("/dev/serial0", timeout=0.1, write_timeout=1)
     bridge.serial = serial.serial_for_url(
         "loop://",
         baudrate=115200,
         do_not_open=True,
         timeout=bridge.timeout,
-        write_timeout=bridge.write_timeout
+        write_timeout=bridge.write_timeout,
     )
     bridge.connect()
-    bridge.queue_write(msg)
-    raw: bytes = bridge.get(timeout=3)
-    assert raw == msg
+    yield bridge
     bridge.close()
+
+
+def test_uart_roundtrip(uart_bridge: UARTBridge) -> None:
+    msg: bytes = b"testing123\n"
+    uart_bridge.queue_write(msg)
+    raw: bytes = uart_bridge.get(timeout=3)
+    assert raw == msg
+
+
+def test_uart_bulk_write(uart_bridge: UARTBridge) -> None:
+    msgs = [f"msg{i}\n".encode() for i in range(10)]
+    for msg in msgs:
+        uart_bridge.queue_write(msg)
+
+    start = time.monotonic()
+    received = [uart_bridge.get(timeout=3) for _ in msgs]
+    elapsed = time.monotonic() - start
+
+    assert received == msgs
+    # All messages should arrive well under one timeout period each
+    # if only one is sent per loop they would take ~N * timeout (1.0s).
+    assert elapsed < len(msgs) * uart_bridge.timeout / 2
+
+
+def test_uart_bulk_read(uart_bridge: UARTBridge) -> None:
+    msgs = [f"msg{i}\n".encode() for i in range(10)]
+    for msg in msgs:
+        # pre-fill buffer
+        uart_bridge.write_sync(msg)
+
+    start = time.monotonic()
+    received = [uart_bridge.get(timeout=3) for _ in msgs]
+    elapsed = time.monotonic() - start
+
+    assert received == msgs
+    # reading one per loop should still drain them well under N * timeout
+    assert elapsed < len(msgs) * uart_bridge.timeout / 2


### PR DESCRIPTION
Drain queue on every loop, recover from message desync, and clean up try-excepts.

queue_write() should now be much, much faster. Minimum 10x, but realistically it's only limited by the I/O speed now (115200 bit/s). Includes some unit tests that can detect if this problem happens again.