### PR TITLE
Scope connection led

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -545,6 +545,11 @@ def main() -> None:
     rm: pyvisa.ResourceManager = pyvisa.ResourceManager(PYVISA_BACKEND)
     scopes: dict[str, Controller] = {}
 
+    def send_scope_connection_led(state: bool) -> None:
+        msg = f"SP_CON:{int(state)}\n".encode("utf-8")
+        bridge.write_sync(msg)
+        print(f"[UART->PICO] {msg.decode().strip()}")
+
     def connect_to_scope(resource_name: str) -> None:
         try:
             scope: MessageBasedResource = rm.open_resource(
@@ -571,6 +576,7 @@ def main() -> None:
         ctrl = Controller(scope, bridge)
         ctrl.sync_all_channels_from_scope()
         scopes[resource_name] = ctrl
+        send_scope_connection_led(True)
 
     def auto_connect_first_scope() -> None:
         resources = rm.list_resources("(USB?*::INSTR|TCPIP?*::INSTR)")

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -546,7 +546,7 @@ def main() -> None:
     scopes: dict[str, Controller] = {}
 
     def send_scope_connection_led(state: bool) -> None:
-        msg = f"SP_CON:{int(state)}\n".encode("utf-8")
+        msg = f"ISP_CON:{int(state)}\n".encode("utf-8")
         bridge.write_sync(msg)
         print(f"[UART->PICO] {msg.decode().strip()}")
 

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -620,6 +620,9 @@ def main() -> None:
                                 else:
                                     c = scopes.pop(data.resource_name)
                                     c.scope.close()
+
+                                    if not scopes:
+                                        send_scope_connection_led(False)
                             else:
                                 print(
                                     f"scope {data.resource_name} not enabled: ignoring"
@@ -697,6 +700,7 @@ def main() -> None:
         for ctrl in scopes.values():
             if ctrl:
                 ctrl.scope.close()
+        send_scope_connection_led(False)
         bridge.close()
 
 


### PR DESCRIPTION
Turns on scope connection LED when a connection is established to an oscilloscope. On disabling and closing a scope, the LED turns off. On the main python program closing, the LED also is turned off. Here is a video of that in action: https://youtube.com/shorts/6N5i4bpxsEM?si=R6RaJoaOqttTpy6i
