### PR TITLE
feat: zoom and pan controls

### DIFF
--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -624,6 +624,37 @@ class Controller:
             self.autoset()
             return
 
+        # zoom enable
+        if msg_id == "HZ0":
+            # FIXME: uses scope state
+            cur: str = parse_resp(
+                self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE?"),
+                str
+            )
+            new: str = "ON" if cur in ("OFF", 0) else "OFF"
+            self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE {new}")
+
+        # zoom encoder
+        if msg_id == "HZ1":
+            # FIXME: needs to use 1-2-4 increments
+            cur: int = parse_resp(
+                self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
+                int
+            )
+            new: int = clamp(cur + inp.value, 0.0, 10.0)
+            self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
+
+        # pan encoder
+        if msg_id == "HX1":
+            cur: float = parse_resp(
+                self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:POSITION?"),
+                float
+            )
+            # TODO: how many percent to change for each detent?
+            new: float = clamp(cur + inp.value * 10, 0.0, 100.0)
+            self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:POSITION {new}")
+
+
 class MacroManager:
     NUM_SLOTS = 4
 

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -97,10 +97,17 @@ class Controller:
         self._channels: dict[int, bool] = {ch: False for ch in range(1, self.channel_count + 1)}
         self._source_channel: int = 0
         self._vert_fine: bool = False # fine mode toggle for vertical scale
-
         self._fast_acquire: bool = False
-
         self._run_state: bool = False
+        self._zoom: bool = False
+
+    def sync_zoom(self) -> None:
+        resp: str = parse_resp(
+            self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE?"), str
+        )
+        self._zoom = resp not in ("OFF", 0)
+        msg = f"IHZ0:{self._zoom}\n".encode()
+        self.bridge.write_sync(msg)
 
     def _channels_from_idn(self, idn: str) -> int:
         m = re.search(r"MSO\d(\d)", idn, re.IGNORECASE)
@@ -626,17 +633,11 @@ class Controller:
 
         # zoom enable
         if msg_id == "HZ0":
-            # FIXME: uses scope state
-            cur: str = parse_resp(
-                self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE?"),
-                str
-            )
-            new: str = "ON" if cur in ("OFF", 0) else "OFF"
+            new: int = int(not self._zoom)
             self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE {new}")
 
         # zoom encoder
         if msg_id == "HZ1":
-            # FIXME: needs to use 1-2-4 increments
             cur: float = parse_resp(
                 self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
                 float
@@ -644,7 +645,14 @@ class Controller:
             if cur <= 1 and inp.value > 0:
                 # match MSO behavior: if the zoom is adjusted, then turn it on
                 self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE ON")
-            new: int = int(clamp(cur + inp.value, 0.0, 10.0))
+            nearest = min(
+                range(len(HORIZ_SCALE_STEPS)),
+                key=lambda i: abs(HORIZ_SCALE_STEPS[i] - cur),
+            )
+            new_idx = int(
+                clamp(nearest + int(inp.value), 0, len(HORIZ_SCALE_STEPS) - 1)
+            )
+            new: int = int(clamp(HORIZ_SCALE_STEPS[new_idx], 0.0, 10.0))
             self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
 
         # pan encoder
@@ -981,6 +989,7 @@ def main() -> None:
                 ctrl.sync_fast_acquire_from_scope()
                 ctrl.sync_run_stop_from_scope()
                 ctrl.sync_trigger_state()
+                ctrl.sync_zoom()
                 last_sync = now
 
     except KeyboardInterrupt:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -637,11 +637,14 @@ class Controller:
         # zoom encoder
         if msg_id == "HZ1":
             # FIXME: needs to use 1-2-4 increments
-            cur: int = parse_resp(
+            cur: float = parse_resp(
                 self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
-                int
+                float
             )
-            new: int = clamp(cur + inp.value, 0.0, 10.0)
+            if cur <= 1 and inp.value > 0:
+                # match MSO behavior: if the zoom is adjusted, then turn it on
+                self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE ON")
+            new: int = int(clamp(cur + inp.value, 0.0, 10.0))
             self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
 
         # pan encoder

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -72,7 +72,7 @@ _LEVEL_MANTISSAS = [2.0, 4.0, 8.0]
 
 # Zoom scale: 1/2/4 (same as horizontal)
 # Range: index 0 = 1x, 1 = (2x) to index 12 (10000x)
-_ZOOM_MIN_IDX = 1
+_ZOOM_MIN_IDX = 0
 _ZOOM_MAX_IDX = 12
 
 

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -106,7 +106,7 @@ class Controller:
             self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE?"), str
         )
         self._zoom = resp not in ("OFF", 0)
-        msg = f"IHZ0:{self._zoom}\n".encode()
+        msg = f"IHZ0:{int(self._zoom)}\n".encode()
         self.bridge.write_sync(msg)
 
     def _channels_from_idn(self, idn: str) -> int:
@@ -635,6 +635,7 @@ class Controller:
         if msg_id == "HZ0":
             new: int = int(not self._zoom)
             self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE {new}")
+            return
 
         # zoom encoder
         if msg_id == "HZ1":
@@ -642,7 +643,7 @@ class Controller:
                 self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
                 float
             )
-            if cur <= 1 and inp.value > 0:
+            if not self._zoom and cur <= 1 and val > 0:
                 # match MSO behavior: if the zoom is adjusted, then turn it on
                 self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE ON")
             nearest = min(
@@ -650,10 +651,14 @@ class Controller:
                 key=lambda i: abs(HORIZ_SCALE_STEPS[i] - cur),
             )
             new_idx = int(
-                clamp(nearest + int(inp.value), 0, len(HORIZ_SCALE_STEPS) - 1)
+                clamp(nearest + val, 0, len(HORIZ_SCALE_STEPS) - 1)
             )
-            new: int = int(clamp(HORIZ_SCALE_STEPS[new_idx], 0.0, 10.0))
-            self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
+            new: int = int(clamp(HORIZ_SCALE_STEPS[new_idx], 0.0, 10e3))
+            if new < 2.0:
+                self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE OFF")
+            else:
+                self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
+            return
 
         # pan encoder
         if msg_id == "HX1":
@@ -664,6 +669,7 @@ class Controller:
             # TODO: how many percent to change for each detent?
             new: float = clamp(cur + inp.value * 10, 0.0, 100.0)
             self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:POSITION {new}")
+            return
 
 
 class MacroManager:

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -105,7 +105,7 @@ class Controller:
         resp: str = parse_resp(
             self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE?"), str
         )
-        self._zoom = resp not in ("OFF", 0)
+        self._zoom = resp not in ("OFF", "0")
         msg = f"IHZ0:{int(self._zoom)}\n".encode()
         self.bridge.write_sync(msg)
 
@@ -643,7 +643,7 @@ class Controller:
                 self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
                 float
             )
-            if not self._zoom and cur <= 1 and val > 0:
+            if not self._zoom and cur <= 2 and val > 0:
                 # match MSO behavior: if the zoom is adjusted, then turn it on
                 self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE ON")
             nearest = min(
@@ -662,12 +662,14 @@ class Controller:
 
         # pan encoder
         if msg_id == "HX1":
+            if not self._zoom:
+                return
             cur: float = parse_resp(
                 self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:POSITION?"),
                 float
             )
             # TODO: how many percent to change for each detent?
-            new: float = clamp(cur + inp.value * 10, 0.0, 100.0)
+            new: float = clamp(cur + val * 2, 0.0, 100.0)
             self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:POSITION {new}")
             return
 

--- a/software/tekafp/__main__.py
+++ b/software/tekafp/__main__.py
@@ -70,6 +70,11 @@ _HORIZ_MAX_IDX = 9
 # e.g. 100mV/div -> 2mV/step, 200mV/div -> 4mV/step, 1V/div -> 20mV/step
 _LEVEL_MANTISSAS = [2.0, 4.0, 8.0]
 
+# Zoom scale: 1/2/4 (same as horizontal)
+# Range: index 0 = 1x, 1 = (2x) to index 12 (10000x)
+_ZOOM_MIN_IDX = 1
+_ZOOM_MAX_IDX = 12
+
 
 def connect_uart(mock: bool = False) -> UARTBridge:
     if mock:
@@ -383,6 +388,22 @@ class Controller:
             f"{cur:.3e} -> {actual:.3e} s/div"
         )
 
+    def adjust_zoom_scale(self, detents: int) -> None:
+        cur: float = parse_resp(
+            self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
+            float
+        )
+        if not self._zoom and cur <= 2 and detents > 0:
+            self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE ON")
+        nearest = _scale_val_to_idx(max(cur, 1.0))
+        new_idx = int(clamp(nearest + detents, _ZOOM_MIN_IDX, _ZOOM_MAX_IDX))
+        new = _scale_idx_to_val(_HORIZ_MANTISSAS, new_idx)
+        if new < 2.0:
+            self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE OFF")
+        else:
+            self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
+        print(f"[SCOPE] zoom scale: {cur:.3e} -> {new:.3e}x")
+
     def encoder_trigger_level(self, detents: int, trigger: str = "A") -> None:
         # FIXME: the MSO has both A (primary) and B (delay) triggers for sequencing.
         # for now, default to A
@@ -639,25 +660,7 @@ class Controller:
 
         # zoom encoder
         if msg_id == "HZ1":
-            cur: float = parse_resp(
-                self.scope.query("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE?"),
-                float
-            )
-            if not self._zoom and cur <= 2 and val > 0:
-                # match MSO behavior: if the zoom is adjusted, then turn it on
-                self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE ON")
-            nearest = min(
-                range(len(HORIZ_SCALE_STEPS)),
-                key=lambda i: abs(HORIZ_SCALE_STEPS[i] - cur),
-            )
-            new_idx = int(
-                clamp(nearest + val, 0, len(HORIZ_SCALE_STEPS) - 1)
-            )
-            new: int = int(clamp(HORIZ_SCALE_STEPS[new_idx], 0.0, 10e3))
-            if new < 2.0:
-                self.scope.write("DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:STATE OFF")
-            else:
-                self.scope.write(f"DISPLAY:WAVEVIEW1:ZOOM:ZOOM1:HORIZONTAL:SCALE {new}")
+            self.adjust_zoom_scale(val)
             return
 
         # pan encoder


### PR DESCRIPTION
This adds zoom and pan controls, including LEDs and state syncing. The behavior of the zoom controls matches the MSO. For example, if the zoom knob is turned to increase zoom, but zoom is not yet enabled, it will automatically enable zoom. Similarly, if the zoom is decreased to 1x, zoom is disabled. The zoom encoder steps match the horizontal scaling, just as on the MSO.